### PR TITLE
feat: Querydsl 환경구성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,8 +35,18 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
+	//Querydsl 추가
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+clean {
+	delete file('src/main/generated')
 }

--- a/src/main/java/umc/catchy/global/config/querydsl/QueryDslConfig.java
+++ b/src/main/java/umc/catchy/global/config/querydsl/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package umc.catchy.global.config.querydsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## 📌 Issue Number

- close #7 

## 🪐 작업 내용

- QueryDsl 을 사용하기 위한 의존성 추가

## ✅ PR 상세 내용

- gradle에 querydsl 의존성추가(Q타입을 버전관리(GIT)에 포함하지않기 위해 gradle build 폴더아래 생성하도록 설정)
- global/config/querydsl 패키지에 QueryDslConfig 설정

## 📸 스크린샷(선택)

- 

## ❌ 애로 사항

- 

## 📚 Reference

- https://docs.google.com/document/d/1j0jcJ9EoXMGzwAA2H0b9TOvRtpwlxI5Dtn3sRtuXQas/edit?tab=t.0#heading=h.vfy9wirpglmx
