### PR TITLE
[feature] CI/CD 파이프라인 구축

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
 
     steps:
@@ -46,6 +47,11 @@ jobs:
           docker build --platform linux/amd64 -t ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }} .
           docker push ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
 
+  deploy:
+    needs: build
+    name: Deploy
+    runs-on: ubuntu-latest
+    steps:
       - name: 6) Deploy
         uses: appleboy/ssh-action@master
         with:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,0 +1,67 @@
+name: CI/CD with Docker & Github Action
+
+on:
+  push:
+    branches: ["develop"]
+  pull_request:
+    branches: ["develop"]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: 1) Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: 2) Set prod.yml
+        uses: microsoft/variable-substitution@v1
+        with:
+          files: ./src/main/resources/application-prod.yml
+        env:
+          spring.datasource.url: ${{ secrets.DB_URL }}
+          spring.datasource.username: ${{ secrets.DB_USERNAME }}
+          spring.datasource.password: ${{ secrets.DB_PASSWORD }}
+          #cloud.aws.s3.bucket: ${{ secrets.S3_BUCKET }}
+          #cloud.aws.s3.region.static: ${{ secrets.S3_REGION }}
+          #cloud.aws.s3.credentials.accessKey: ${{ secrets.S3_ACCESS_KEY }}
+          #cloud.aws.s3.credentials.secretKey: ${{ secrets.S3_SECRET_KEY }}
+
+      - name: 3)Grant permission
+        run: chmod +x ./gradlew
+
+      - name: 4) Build with Gradle
+        run: ./gradlew bootJar
+
+      - name: 5) Docker build and push
+        run: |
+          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+          docker build --platform linux/amd64 -t ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }} .
+          docker push ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
+
+      - name: 6) Deploy
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_KEY }}
+          port: 22
+          script: |
+            sudo docker stop catchy-server || true
+            sudo docker rm catchy-server || true
+            sudo docker image rm ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }} || true
+            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
+            sudo docker run -d --name catchy-server \
+              -p 8081:8081 \
+              -e DB_URL=${{ secrets.DB_URL }} \
+              -e DB_USERNAME=${{ secrets.DB_USERNAME }} \
+              -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
+              ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
+            sudo docker image prune -f

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:17
+ARG JAR_FILE=./build/libs/*.jar
+COPY ${JAR_FILE} /app.jar
+ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-jar", "/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,17 @@
+spring:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  datasource:
+    url: jdbc:h2:~/catchy
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.H2Dialect

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -7,10 +7,9 @@ spring:
 
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect
-    open-in-view: false
-    show-sql: true
     hibernate:
-      ddl-auto: update # 첫 배포 이후 validate 으로 수정
+      ddl-auto: update # 배포 환경에서는 update
+    show-sql: false
 
   servlet:
     multipart:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -10,7 +10,7 @@ spring:
     open-in-view: false
     show-sql: true
     hibernate:
-      ddl-auto: validate # 첫 배포 이후 validate 으로 수정
+      ddl-auto: update # 첫 배포 이후 validate 으로 수정
 
   servlet:
     multipart:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,21 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+
+  jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
+    open-in-view: false
+    show-sql: true
+    hibernate:
+      ddl-auto: validate # 첫 배포 이후 validate 으로 수정
+
+  servlet:
+    multipart:
+      max-file-size: 50MB
+      max-request-size: 50MB
+
+server:
+  port: 8081

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,17 +1,3 @@
 spring:
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
-  datasource:
-    url: jdbc:h2:~/catchy
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
-  jpa:
-    hibernate:
-      ddl-auto: update
-    properties:
-      hibernate:
-        format_sql: true
-        dialect: org.hibernate.dialect.H2Dialect
+  profiles:
+    active: local


### PR DESCRIPTION
## 📌 Issue Number

- close #9 

## 🪐 작업 내용

- Docker & Github Actions & AWS EC2를 이용한 CI/CD 파이프라인 구축

## ✅ PR 상세 내용

- Dockerfile 작성
- github-actions.yml 작성
- application-prod.yml 작성
- AWS에서 EC2 및 rds 구축

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/1237cfc4-b8dd-436a-9a69-f4f62d2d721c)
앞으로 해당 링크에서 스웨거 확인할 수 있습니다. 
(http://ec2-3-34-59-249.ap-northeast-2.compute.amazonaws.com:8081/swagger-ui/index.html)

## ❌ 애로 사항
로컬환경에서는 h2, 배포환경에서는 mysql 사용으로 인해 배포 환경에서 DB 드라이버 사이의 충돌 발생, 설정 별 프로필 분리를 통해 해당 문제 해결함.

## 📚 Reference
[CI/CD 파이프라인 구축 with Docker]
https://velog.io/@leeeeeyeon/Github-Actions%EA%B3%BC-Docker%EC%9D%84-%ED%99%9C%EC%9A%A9%ED%95%9C-CICD-%EA%B5%AC%EC%B6%95

[설정 별 프로필 분리]
https://developerbee.tistory.com/272