### PR TITLE
[feature] 사용자의 코스 조회

### DIFF
--- a/src/main/java/umc/catchy/domain/course/api/CourseController.java
+++ b/src/main/java/umc/catchy/domain/course/api/CourseController.java
@@ -3,14 +3,17 @@ package umc.catchy.domain.course.api;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import umc.catchy.domain.course.dto.response.CourseInfoResponse;
 import umc.catchy.domain.course.service.CourseService;
+import umc.catchy.domain.mapping.memberCourse.dto.response.MemberCourseResponse;
 import umc.catchy.global.common.response.BaseResponse;
 import umc.catchy.global.common.response.status.SuccessStatus;
 
@@ -30,5 +33,17 @@ public class CourseController {
     ){
         CourseInfoResponse.getCourseInfoDTO response= courseService.getCourseDetails(courseId);
         return ResponseEntity.ok(BaseResponse.onSuccess(SuccessStatus._OK, response));
+    }
+
+    @Operation(summary = "내 코스 조회 API", description = "코스 탭에서 DIY/AI, 지역별로 사용자의 코스를 조회")
+    @GetMapping("/course/search")
+    public ResponseEntity<BaseResponse<List<MemberCourseResponse>>> getMemberCourses(
+            @RequestParam(value = "type", defaultValue = "AI") String type,
+            @RequestParam(value = "upperLocation", defaultValue = "all") String upperLocation,
+            @RequestParam(value = "lowerLocation", defaultValue = "all") String lowerLocation
+    ) {
+
+        List<MemberCourseResponse> responses = courseService.getMemberCourses(type, upperLocation, lowerLocation);
+        return ResponseEntity.ok(BaseResponse.onSuccess(SuccessStatus._OK, responses));
     }
 }

--- a/src/main/java/umc/catchy/domain/course/service/CourseService.java
+++ b/src/main/java/umc/catchy/domain/course/service/CourseService.java
@@ -1,19 +1,29 @@
 package umc.catchy.domain.course.service;
 
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.catchy.domain.category.domain.BigCategory;
+import umc.catchy.domain.category.domain.Category;
 import umc.catchy.domain.course.converter.CourseConverter;
 import umc.catchy.domain.course.dao.CourseRepository;
 import umc.catchy.domain.course.domain.Course;
+import umc.catchy.domain.course.domain.CourseType;
 import umc.catchy.domain.course.dto.response.CourseInfoResponse;
 import umc.catchy.domain.courseReview.dao.CourseReviewRepository;
+import umc.catchy.domain.mapping.memberCourse.converter.MemberCourseConverter;
+import umc.catchy.domain.mapping.memberCourse.dao.MemberCourseRepository;
+import umc.catchy.domain.mapping.memberCourse.domain.MemberCourse;
+import umc.catchy.domain.mapping.memberCourse.dto.response.MemberCourseResponse;
 import umc.catchy.domain.mapping.placeCourse.dao.PlaceCourseRepository;
+import umc.catchy.domain.mapping.placeCourse.domain.PlaceCourse;
 import umc.catchy.domain.mapping.placeVisit.dao.PlaceVisitRepository;
 import umc.catchy.domain.mapping.placeVisit.domain.PlaceVisit;
 import umc.catchy.domain.member.dao.MemberRepository;
 import umc.catchy.domain.member.domain.Member;
 import umc.catchy.domain.place.converter.PlaceConverter;
+import umc.catchy.domain.place.domain.Place;
 import umc.catchy.global.common.response.status.ErrorStatus;
 import umc.catchy.global.error.exception.GeneralException;
 import umc.catchy.global.util.SecurityUtil;
@@ -32,6 +42,7 @@ public class CourseService {
     private final PlaceCourseRepository placeCourseRepository;
     private final PlaceVisitRepository placeVisitRepository;
     private final MemberRepository memberRepository;
+    private final MemberCourseRepository memberCourseRepository;
 
     private Course getCourse(Long courseId){
         return courseRepository.findById(courseId)
@@ -84,5 +95,103 @@ public class CourseService {
 
         List<CourseInfoResponse.getPlaceInfoOfCourseDTO> placeListOfCourse = getPlaceListOfCourse(course, member);
         return CourseConverter.toCourseInfoDTO(course, calculateRatingOfCourse(course), calculateNumberOfReviews(course), getRecommendTimeToString(course), placeListOfCourse);
+    }
+
+    // 현재 사용자의 코스를 불러옴
+    public List<MemberCourseResponse> getMemberCourses(String type, String upperLocation, String lowerLocation) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        List<MemberCourse> memberCourses = memberCourseRepository.findAllByMember(member);
+
+        CourseType courseType;
+
+        if (type.equals("AI")) courseType = CourseType.AI_GENERATED;
+        else if (type.equals("DIY")) courseType = CourseType.USER_CREATED;
+        else throw new GeneralException(ErrorStatus.INVALID_COURSE_TYPE);
+
+        List<Course> courses = filterByConditions(memberCourses, courseType, upperLocation, lowerLocation);
+
+        return courses.stream()
+                .map(course -> {
+                    List<BigCategory> categories = getCategories(course);
+                    return MemberCourseConverter.toMemberCourseResponse(course, categories);
+                }).toList();
+    }
+
+    private List<BigCategory> getCategories(Course course) {
+        List<PlaceCourse> placeCourses = placeCourseRepository.findAllByCourse(course);
+
+        return placeCourses.stream()
+                .map(PlaceCourse::getPlace)
+                .map(Place::getCategory)
+                .map(Category::getBigCategory)
+                .distinct()
+                .toList();
+    }
+
+    // 통합 필터
+    private List<Course> filterByConditions(List<MemberCourse> memberCourses, CourseType courseType, String upperLocation, String lowerLocation) {
+        List<Course> filteredByCourseType = filterByCourseType(memberCourses, courseType);
+        List<Course> filteredByUpperLocation = filterByUpperLocation(filteredByCourseType, upperLocation);
+
+        return filterByLowerLocation(filteredByUpperLocation, lowerLocation);
+    }
+
+    // courseType에 따라 필터링
+    private List<Course> filterByCourseType(List<MemberCourse> memberCourses, CourseType courseType) {
+        return memberCourses.stream()
+                .map(MemberCourse::getCourse)
+                .filter(course -> course.getCourseType().equals(courseType))
+                .toList();
+    }
+
+    // 상위 지역에 따라 필터링
+    private List<Course> filterByUpperLocation(List<Course> courses, String upperLocation) {
+        if (upperLocation.equals("all")) return courses;
+
+        // hasUpperLocation이 true인 course만 반환
+        return courses.stream()
+                .filter(course -> {
+                    List<PlaceCourse> placeCourses = placeCourseRepository.findAllByCourse(course);
+                    return hasUpperLocation(placeCourses, upperLocation);
+                }).distinct().toList();
+    }
+
+    // 하위 지역에 따라 필터링
+    private List<Course> filterByLowerLocation(List<Course> courses, String lowerLocation) {
+        if (lowerLocation.equals("all")) return courses;
+
+        // hasLowerLocation이 true인 course만 반환
+        return courses.stream()
+                .filter(course -> {
+                    List<PlaceCourse> placeCourses = placeCourseRepository.findAllByCourse(course);
+                    return hasLowerLocation(placeCourses, lowerLocation);
+                }).distinct().toList();
+    }
+
+    private boolean hasUpperLocation(List<PlaceCourse> placeCourses, String upperLocation) {
+        // 코스에 요청받은 상위 지역에 해당하는 장소가 있으면 true 반환
+        return placeCourses.stream()
+                .map(PlaceCourse::getPlace)
+                .anyMatch(place -> {
+                    List<String> roadAddress = Arrays.stream(place.getRoadAddress().split(" ")).toList();
+
+                    // 상위 지역(도) 확인
+                    return roadAddress.get(0).equals(upperLocation);
+                });
+    }
+
+    private boolean hasLowerLocation(List<PlaceCourse> placeCourses, String lowerLocation) {
+        // 코스에 요청받은 하위 지역에 해당하는 장소가 있으면 true 반환
+        return placeCourses.stream()
+                .map(PlaceCourse::getPlace)
+                .anyMatch(place -> {
+                    List<String> roadAddress = Arrays.stream(place.getRoadAddress().split(" ")).toList();
+
+                    // 하위 지역(시,군,구) 확인
+                    return roadAddress.get(1).equals(lowerLocation);
+                });
     }
 }

--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/converter/MemberCourseConverter.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/converter/MemberCourseConverter.java
@@ -1,0 +1,23 @@
+package umc.catchy.domain.mapping.memberCourse.converter;
+
+import java.util.List;
+import umc.catchy.domain.category.domain.BigCategory;
+import umc.catchy.domain.course.domain.Course;
+import umc.catchy.domain.mapping.memberCourse.dto.response.MemberCourseResponse;
+
+public class MemberCourseConverter {
+
+    public static MemberCourseResponse toMemberCourseResponse(
+            Course course,
+            List<BigCategory> categories
+    ) {
+        return MemberCourseResponse.builder()
+                .courseId(course.getId())
+                .courseType(course.getCourseType())
+                .courseImage(course.getCourseImage())
+                .courseName(course.getCourseName())
+                .courseDescription(course.getCourseDescription())
+                .categories(categories)
+                .build();
+    }
+}

--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/dao/MemberCourseRepository.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/dao/MemberCourseRepository.java
@@ -1,0 +1,10 @@
+package umc.catchy.domain.mapping.memberCourse.dao;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.catchy.domain.mapping.memberCourse.domain.MemberCourse;
+import umc.catchy.domain.member.domain.Member;
+
+public interface MemberCourseRepository extends JpaRepository<MemberCourse, Long> {
+    List<MemberCourse> findAllByMember(Member member);
+}

--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/dto/response/MemberCourseResponse.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/dto/response/MemberCourseResponse.java
@@ -1,0 +1,22 @@
+package umc.catchy.domain.mapping.memberCourse.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.catchy.domain.category.domain.BigCategory;
+import umc.catchy.domain.course.domain.CourseType;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberCourseResponse {
+    Long courseId;
+    CourseType courseType;
+    String courseImage;
+    String courseName;
+    String courseDescription;
+    List<BigCategory> categories;
+}

--- a/src/main/java/umc/catchy/global/common/response/status/ErrorStatus.java
+++ b/src/main/java/umc/catchy/global/common/response/status/ErrorStatus.java
@@ -27,8 +27,9 @@ public enum ErrorStatus implements BaseErrorCode {
     NICKNAME_DUPLICATE(HttpStatus.CONFLICT, "MEMBER409", "이미 사용 중인 닉네임입니다."),
     APPLE_WITHDRAW_FAILED(HttpStatus.UNAUTHORIZED, "MEMBER401", "애플 회원탈퇴에 실패하였습니다."),
 
-    //코스 관련 에러
+    // 코스 관련 에러
     COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "COURSE404", "해당 코스를 찾을 수 없습니다."),
+    INVALID_COURSE_TYPE(HttpStatus.BAD_REQUEST, "COURSE_TYPE400", "코스타입 입력이 잘못되었습니다."),
 
     // 그룹 관련 에러
     GROUP_INVITE_CODE_INVALID(HttpStatus.BAD_REQUEST, "GROUP400", "유효하지 않은 초대 코드입니다."),


### PR DESCRIPTION
## 📌 Issue Number

- close #51 

## 🪐 작업 내용

- 현 로그인 상태인 사용자의 코스 조회

## ✅ PR 상세 내용

- AI/DIY 별로 조회
- 지역 별로 조회
  - 검색한 지역이 코스의 장소들에 있는 지역일 때  
- 대카테고리 조회
  -  검색한 코스들에 포함된 지역들의 대카테고리를 함께 출력

## 📸 스크린샷(선택)

검색 예시

- AI, 시(전체), 구(전체)
<img width="319" alt="image" src="https://github.com/user-attachments/assets/0e939704-fd13-457d-a57e-b1358a82b0c8" />

- DIY, 시(전체), 구(전체)
<img width="322" alt="image" src="https://github.com/user-attachments/assets/357878a3-04e9-4350-ad02-3ee44381c826" />

- DIY, 서울시, 노원구
<img width="343" alt="image" src="https://github.com/user-attachments/assets/74701405-8260-4f3c-9777-58e328d3b75c" />

- AI, 경기도, 구리시
<img width="310" alt="image" src="https://github.com/user-attachments/assets/ac0d1418-ad27-4da7-a1bb-eeb1d2e3b529" />


## ❌ 애로 사항


## 📚 Reference

