### PR TITLE
[fix] 코스 평점 계산 로직 추가

### DIFF
--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/dao/PlaceCourseRepository.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/dao/PlaceCourseRepository.java
@@ -6,10 +6,15 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import umc.catchy.domain.course.domain.Course;
 import umc.catchy.domain.mapping.placeCourse.domain.PlaceCourse;
+import umc.catchy.domain.place.domain.Place;
 
 import java.util.List;
 
 @Repository
 public interface PlaceCourseRepository extends JpaRepository<PlaceCourse, Long> {
-    List<PlaceCourse> findAllByCourse(@Param("course") Course course);
+    List<PlaceCourse> findAllByCourse(Course course);
+    List<PlaceCourse> findAllByPlace(Place place);
+
+    @Query("SELECT AVG(pc.place.rating) FROM PlaceCourse pc WHERE pc.course = :course AND pc.place.rating > 0")
+    Double calculateAverageRatingByCourse(@Param("course") Course course);
 }


### PR DESCRIPTION
## 📌 Issue Number

- close #57 

## 🪐 작업 내용

- 코스 평점(해당 코스에 포함되는 모든 장소 평점의 평균) 
=> 장소 평점/리뷰 생성 시점에 코스 평점을 갱신하도록 로직 구현
- 평점 계산 성능을 고려하여 JPQL을 이용해 데이터베이스 상에서 계산하도록 함.

## ✅ PR 상세 내용

- 코스 평점 계산 및 갱신 로직 추가

## 📸 스크린샷(선택)

## ❌ 애로 사항

- 코스 평점 갱신에 대하여 책임 분리 원칙에 따라 CourseService에 구현할지, 기능이 실제로 실행되는 PlaceReviewService에 구현할지 고민되었음. 
=> 서비스에서 코스 평점은 장소 평점/리뷰의 생성&신고&삭제 순간에만 갱신 된다고 판단.
해당 로직을 PlaceReviewService에 구현함.

## 📚 Reference
1. 갱신 로직이 PlaceReviewService에서만 필요하다면?
평점 갱신 작업이 단순하고 PlaceReviewService 외 다른 서비스에서 절대 사용되지 않는다면, PlaceReviewService가 CourseRepository를 직접 사용하는 것이 더 간단하고 적절합니다.
2. 갱신 로직이 재사용될 가능성이 있다면?
현재는 PlaceReviewService에서만 필요하더라도, 평점 갱신 로직이 다른 서비스나 유스케이스에서도 필요해질 가능성이 있다면, CourseService를 통해 구현하는 것이 좋습니다.