### PR TITLE
[feature] 찜한 코스 조회

### DIFF
--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/api/MemberCourseController.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/api/MemberCourseController.java
@@ -1,0 +1,27 @@
+package umc.catchy.domain.mapping.memberCourse.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import umc.catchy.domain.mapping.memberCourse.dto.response.MemberCourseResponse;
+import umc.catchy.domain.mapping.memberCourse.service.MemberCourseService;
+import umc.catchy.global.common.response.BaseResponse;
+import umc.catchy.global.common.response.status.SuccessStatus;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberCourseController {
+    private final MemberCourseService memberCourseService;
+
+    @Operation(summary = "북마크된 코스 무한 스크롤 API", description = "북마크된 코스 정보들을 무한 스크롤로 보여줍니다.")
+    @GetMapping("/mypage/bookmark")
+    public BaseResponse<Slice<MemberCourseResponse>> findAllCourseByBookmarked(@RequestParam int pageSize,
+                                                                                               @RequestParam(required = false) Long lastCourseId) {
+        Slice<MemberCourseResponse> response = memberCourseService.findAllCourseByBookmarked(pageSize, lastCourseId);
+        return BaseResponse.onSuccess(SuccessStatus._OK,response);
+    }
+}

--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/dao/MemberCourseRepository.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/dao/MemberCourseRepository.java
@@ -10,7 +10,7 @@ import umc.catchy.domain.member.domain.Member;
 import java.util.Optional;
 
 @Repository
-public interface MemberCourseRepository extends JpaRepository<MemberCourse, Long> {
+public interface MemberCourseRepository extends JpaRepository<MemberCourse, Long>, MemberCourseRepositoryCustom {
     Optional<MemberCourse> findByCourseAndMember(Course course, Member member);
     List<MemberCourse> findAllByMember(Member member);
     Optional<MemberCourse> findByCourseIdAndMemberId(Long courseId, Long memberId);

--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/dao/MemberCourseRepositoryCustom.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/dao/MemberCourseRepositoryCustom.java
@@ -1,0 +1,9 @@
+package umc.catchy.domain.mapping.memberCourse.dao;
+
+import org.springframework.data.domain.Slice;
+import umc.catchy.domain.mapping.memberCourse.dto.response.MemberCourseResponse;
+
+public interface MemberCourseRepositoryCustom {
+
+    Slice<MemberCourseResponse> findCourseByBookmarks(Long memberId, int pageSize, Long lastCourseId);
+}

--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/dao/MemberCourseRepositoryImpl.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/dao/MemberCourseRepositoryImpl.java
@@ -12,6 +12,8 @@ import umc.catchy.domain.category.domain.BigCategory;
 import umc.catchy.domain.mapping.memberCourse.dto.response.MemberCourseResponse;
 
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import static umc.catchy.domain.course.domain.QCourse.course;
@@ -47,12 +49,13 @@ public class MemberCourseRepositoryImpl implements MemberCourseRepositoryCustom 
                 .fetch();
 
         for (MemberCourseResponse result : results) {
-            List<BigCategory> bigCategories = queryFactory.select(placeCourse.place.category.bigCategory)
+            List<BigCategory> bigCategoriesDuplicates = queryFactory.select(placeCourse.place.category.bigCategory)
                     .from(placeCourse)
                     .innerJoin(placeCourse.place,place).on(placeCourse.place.id.eq(place.id))
                     .innerJoin(placeCourse.course,course).on(placeCourse.course.id.eq(course.id))
                     .where(placeCourse.course.id.eq(result.getCourseId()))
                     .fetch();
+            List<BigCategory> bigCategories = new ArrayList<>(new HashSet<>(bigCategoriesDuplicates));
             result.setCategories(bigCategories);
         }
 

--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/dao/MemberCourseRepositoryImpl.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/dao/MemberCourseRepositoryImpl.java
@@ -8,11 +8,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
-import umc.catchy.domain.mapping.memberCourse.domain.QMemberCourse;
+
 import umc.catchy.domain.mapping.memberCourse.dto.response.MemberCourseResponse;
-import umc.catchy.domain.mapping.placeCourse.domain.QPlaceCourse;
-import umc.catchy.domain.member.domain.QMember;
-import umc.catchy.domain.place.domain.QPlace;
+
 
 import java.util.List;
 

--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/dao/MemberCourseRepositoryImpl.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/dao/MemberCourseRepositoryImpl.java
@@ -1,0 +1,81 @@
+package umc.catchy.domain.mapping.memberCourse.dao;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import umc.catchy.domain.mapping.memberCourse.domain.QMemberCourse;
+import umc.catchy.domain.mapping.memberCourse.dto.response.MemberCourseResponse;
+import umc.catchy.domain.mapping.placeCourse.domain.QPlaceCourse;
+import umc.catchy.domain.member.domain.QMember;
+import umc.catchy.domain.place.domain.QPlace;
+
+import java.util.List;
+
+import static umc.catchy.domain.course.domain.QCourse.course;
+import static umc.catchy.domain.mapping.memberCourse.domain.QMemberCourse.*;
+import static umc.catchy.domain.mapping.placeCourse.domain.QPlaceCourse.*;
+import static umc.catchy.domain.member.domain.QMember.*;
+import static umc.catchy.domain.place.domain.QPlace.*;
+
+@RequiredArgsConstructor
+public class MemberCourseRepositoryImpl implements MemberCourseRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<MemberCourseResponse> findCourseByBookmarks(Long memberId, int pageSize, Long lastCourseId) {
+
+        List<MemberCourseResponse> results = queryFactory.select(Projections.constructor(MemberCourseResponse.class,
+                        course.id,
+                        course.courseType,
+                        course.courseImage,
+                        course.courseName,
+                        course.courseDescription,
+                        JPAExpressions
+                                .select(place.category.bigCategory)
+                                .from(placeCourse)
+                                .leftJoin(placeCourse.place, place)
+                                .on(placeCourse.place.id.eq(place.id))
+                                .where(placeCourse.course.id.eq(course.id))
+                )).from(memberCourse)
+                .leftJoin(memberCourse.course, course)
+                .on(memberCourse.course.id.eq(course.id))
+                .leftJoin(memberCourse.member, member)
+                .on(memberCourse.member.id.eq(member.id))
+                .where(
+                        memberCourse.member.id.eq(memberId),
+                        lastCourseId(lastCourseId),
+                        markedCondition
+                ).orderBy(course.createdDate.desc())
+                .limit(pageSize + 1)
+                .fetch();
+
+        return checkLastPage(pageSize,results);
+    }
+
+    private BooleanExpression markedCondition = memberCourse.bookmark.eq(true);
+
+    private BooleanExpression lastCourseId(Long courseId) {
+        if (courseId == null) {
+            return null;
+        }
+        return course.id.lt(courseId);
+    }
+
+    private Slice<MemberCourseResponse> checkLastPage(int pageSize, List<MemberCourseResponse> results) {
+        boolean hasNext = false;
+
+        if (results.size() > pageSize) {
+            hasNext = true;
+            results.remove(pageSize);
+        }
+
+        return new SliceImpl<>(results, PageRequest.of(0,pageSize), hasNext);
+    }
+
+}

--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/dto/response/MemberCourseResponse.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/dto/response/MemberCourseResponse.java
@@ -19,4 +19,16 @@ public class MemberCourseResponse {
     String courseName;
     String courseDescription;
     List<BigCategory> categories;
+
+    public MemberCourseResponse(Long courseId, CourseType courseType, String courseImage, String courseName, String courseDescription) {
+        this.courseId = courseId;
+        this.courseType = courseType;
+        this.courseImage = courseImage;
+        this.courseName = courseName;
+        this.courseDescription = courseDescription;
+    }
+
+    public void setCategories(List<BigCategory> categories) {
+        this.categories = categories;
+    }
 }

--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/service/MemberCourseService.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/service/MemberCourseService.java
@@ -2,11 +2,13 @@ package umc.catchy.domain.mapping.memberCourse.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.catchy.domain.mapping.memberCourse.dao.MemberCourseRepository;
 import umc.catchy.domain.mapping.memberCourse.domain.MemberCourse;
 import umc.catchy.domain.mapping.memberCourse.dto.response.CourseBookmarkResponse;
+import umc.catchy.domain.mapping.memberCourse.dto.response.MemberCourseResponse;
 import umc.catchy.domain.member.dao.MemberRepository;
 import umc.catchy.domain.member.domain.Member;
 import umc.catchy.global.common.response.code.BaseErrorCode;
@@ -31,5 +33,12 @@ public class MemberCourseService {
                 .memberCourseId(memberCourse.getId())
                 .bookmarked(memberCourse.isBookmark())
                 .build();
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<MemberCourseResponse> findAllCourseByBookmarked(int pageSize, Long lastCourseId) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        Member currentMember = memberRepository.findById(memberId).orElseThrow(() ->new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+        return memberCourseRepository.findCourseByBookmarks(currentMember.getId(),pageSize,lastCourseId);
     }
 }

--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/service/MemberCourseService.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/service/MemberCourseService.java
@@ -38,7 +38,6 @@ public class MemberCourseService {
     @Transactional(readOnly = true)
     public Slice<MemberCourseResponse> findAllCourseByBookmarked(int pageSize, Long lastCourseId) {
         Long memberId = SecurityUtil.getCurrentMemberId();
-        Member currentMember = memberRepository.findById(memberId).orElseThrow(() ->new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
-        return memberCourseRepository.findCourseByBookmarks(currentMember.getId(),pageSize,lastCourseId);
+        return memberCourseRepository.findCourseByBookmarks(memberId,pageSize,lastCourseId);
     }
 }


### PR DESCRIPTION
## 📌 Issue Number

- close #70  

## 🪐 작업 내용

- 찜한 코스 조회 (무한 스크롤 구현)

## ✅ PR 상세 내용

- querydsl을 적용해 북마크된 코스 무한 스크롤로 구현.

## 📸 스크린샷(선택)

- 성공 시 다음과 같이 나옴 (querystring 으로 pageSize를 넘겨주고, 마지막 페이지가 아닌 경우 마지막 코스id를 넘겨주면 그 이후 데이터로 보여준다. )
<img width="372" alt="image" src="https://github.com/user-attachments/assets/9642135f-3d7c-480a-962a-b66e5cfc82aa" />

<img width="267" alt="image" src="https://github.com/user-attachments/assets/9a074b0e-0839-4658-9282-21ded69dcba4" />


## ❌ 애로 사항

- 현재 custumrepo에서 데이터를 가져올때 N+1 문제가 발생할 수 있어 성능상 문제가 있다. 이 부분에 대해 수정해야 될 필요가 있을 것 같다.
- 또한 마이페이지에 대한 API를 어디에 배치할지 몰라 매핑테이블 도메인에 설정했는데 나중에 이 부분에 대해 논의 할 필요가 있을 것 같다.

## 📚 Reference

- 
