### PR TITLE
[feature] 장소 검색 및 상세 정보 보기

### DIFF
--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/api/PlaceCourseController.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/api/PlaceCourseController.java
@@ -4,13 +4,15 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoResponse;
+import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfo;
 import umc.catchy.domain.mapping.placeCourse.service.PlaceCourseService;
 import umc.catchy.global.common.response.BaseResponse;
+import umc.catchy.global.common.response.status.ErrorStatus;
 import umc.catchy.global.common.response.status.SuccessStatus;
 
 @Tag(name = "PlaceCourse", description = "코스/장소 관련 API")
@@ -23,18 +25,25 @@ public class PlaceCourseController {
 
     @GetMapping("/current")
     @Operation(summary = "내 위치 기반 장소 검색 API", description = "사용자 반경 5km 이내에 사용자 키워드 관련 장소를 불러온다.")
-    public BaseResponse<List<PlaceInfoResponse>> searchPlacesByMemberLocation(
+    public ResponseEntity<BaseResponse<List<PlaceInfo>>> searchPlacesByMemberLocation(
             @RequestParam String searchKeyword,
             @RequestParam Float latitude,
-            @RequestParam Float longitude) {
+            @RequestParam Float longitude,
+            @RequestParam Integer page
+    ) {
+        List<PlaceInfo> responses = placeCourseService.getPlacesByLocation(searchKeyword, latitude, longitude, page);
 
-        return BaseResponse.onSuccess(SuccessStatus._OK, placeCourseService.getPlacesByMemberLocation(searchKeyword, latitude, longitude));
+        return ResponseEntity.ok(BaseResponse.onSuccess(SuccessStatus._OK, responses));
     }
 
     @GetMapping("/region")
     @Operation(summary = "지역명 기반 장소 검색 API", description = "지역명이 포함된 키워드를 받아 관련 장소를 검색")
-    public void searchPlacesByLocation() {
+    public ResponseEntity<BaseResponse<List<PlaceInfo>>> searchPlacesByLocation(
+            @RequestParam String searchKeyword,
+            @RequestParam Integer page
+    ) {
 
+        List<PlaceInfo> responses = placeCourseService.getPlacesByLocation(searchKeyword, null, null, page);
+        return ResponseEntity.ok(BaseResponse.onSuccess(SuccessStatus._OK, responses));
     }
-
 }

--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/api/PlaceCourseController.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/api/PlaceCourseController.java
@@ -28,8 +28,8 @@ public class PlaceCourseController {
     @Operation(summary = "내 위치 기반 장소 검색 API", description = "사용자 반경 5km 이내에 사용자 키워드 관련 장소를 불러온다.")
     public ResponseEntity<BaseResponse<List<PlaceInfo>>> searchPlacesByMemberLocation(
             @RequestParam String searchKeyword,
-            @RequestParam Float latitude,
-            @RequestParam Float longitude,
+            @RequestParam Double latitude,
+            @RequestParam Double longitude,
             @RequestParam Integer page
     ) {
         List<PlaceInfo> responses = placeCourseService.getPlacesByLocation(searchKeyword, latitude, longitude, page);

--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/api/PlaceCourseController.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/api/PlaceCourseController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfo;
+import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoDetail;
 import umc.catchy.domain.mapping.placeCourse.service.PlaceCourseService;
 import umc.catchy.global.common.response.BaseResponse;
 import umc.catchy.global.common.response.status.ErrorStatus;
@@ -45,5 +46,16 @@ public class PlaceCourseController {
 
         List<PlaceInfo> responses = placeCourseService.getPlacesByLocation(searchKeyword, null, null, page);
         return ResponseEntity.ok(BaseResponse.onSuccess(SuccessStatus._OK, responses));
+    }
+
+    @GetMapping
+    @Operation(summary = "지역 상세 화면 API", description = "지도에서 장소 검색 후 클릭하면 나오는 상세 화면")
+    public ResponseEntity<BaseResponse<PlaceInfoDetail>> getPlaceInfoDetail(
+            @RequestParam Long placeId
+    ) {
+
+        PlaceInfoDetail response = placeCourseService.getPlaceDetailByPlaceId(placeId);
+
+        return ResponseEntity.ok(BaseResponse.onSuccess(SuccessStatus._OK, response));
     }
 }

--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/api/PlaceCourseController.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/api/PlaceCourseController.java
@@ -1,0 +1,40 @@
+package umc.catchy.domain.mapping.placeCourse.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoResponse;
+import umc.catchy.domain.mapping.placeCourse.service.PlaceCourseService;
+import umc.catchy.global.common.response.BaseResponse;
+import umc.catchy.global.common.response.status.SuccessStatus;
+
+@Tag(name = "PlaceCourse", description = "코스/장소 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/course/place")
+public class PlaceCourseController {
+
+    private final PlaceCourseService placeCourseService;
+
+    @GetMapping("/current")
+    @Operation(summary = "내 위치 기반 장소 검색 API", description = "사용자 반경 5km 이내에 사용자 키워드 관련 장소를 불러온다.")
+    public BaseResponse<List<PlaceInfoResponse>> searchPlacesByMemberLocation(
+            @RequestParam String searchKeyword,
+            @RequestParam Float latitude,
+            @RequestParam Float longitude) {
+
+        return BaseResponse.onSuccess(SuccessStatus._OK, placeCourseService.getPlacesByMemberLocation(searchKeyword, latitude, longitude));
+    }
+
+    @GetMapping("/region")
+    @Operation(summary = "지역명 기반 장소 검색 API", description = "지역명이 포함된 키워드를 받아 관련 장소를 검색")
+    public void searchPlacesByLocation() {
+
+    }
+
+}

--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/dto/response/PlaceInfo.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/dto/response/PlaceInfo.java
@@ -1,0 +1,19 @@
+package umc.catchy.domain.mapping.placeCourse.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Setter
+@Getter
+public class PlaceInfo {
+    private Long placeId;
+    private Long poiId;
+    private String placeName;
+    private String category;
+    private String roadAddress;
+    private String activeTime;
+    private Double rating;
+    private Long reviewCount;
+}

--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/dto/response/PlaceInfoDetail.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/dto/response/PlaceInfoDetail.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 @Builder
 @Getter
 @Setter
-public class PlaceInfoResponse {
+public class PlaceInfoDetail {
     private Long placeId;
     private Long poiId;
     private String imageUrl;
@@ -16,7 +16,7 @@ public class PlaceInfoResponse {
     private String category;
     private String roadAddress;
     private String activeTime;
+    private String placeSite;
     private Double rating;
     private Long reviewCount;
-    private String placeSite;
 }

--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/dto/response/PlaceInfoResponse.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/dto/response/PlaceInfoResponse.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 @Setter
 public class PlaceInfoResponse {
     private Long placeId;
+    private Long poiId;
     private String imageUrl;
     private String placeName;
     private String placeDescription;

--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/dto/response/PlaceInfoResponse.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/dto/response/PlaceInfoResponse.java
@@ -1,0 +1,21 @@
+package umc.catchy.domain.mapping.placeCourse.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
+public class PlaceInfoResponse {
+    private Long placeId;
+    private String imageUrl;
+    private String placeName;
+    private String placeDescription;
+    private String category;
+    private String roadAddress;
+    private String activeTime;
+    private Double rating;
+    private Long reviewCount;
+    private String placeSite;
+}

--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/service/PlaceCourseService.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/service/PlaceCourseService.java
@@ -18,26 +18,32 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoResponse;
+import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfo;
 import umc.catchy.domain.place.converter.PlaceConverter;
 import umc.catchy.domain.place.dao.PlaceRepository;
 import umc.catchy.domain.place.domain.Place;
 import umc.catchy.domain.placeReview.dao.PlaceReviewRepository;
+import umc.catchy.global.common.response.status.ErrorStatus;
+import umc.catchy.global.error.exception.GeneralException;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class PlaceCourseService {
+    private static final String TMAP_API_URL = "https://apis.openapi.sk.com/tmap/pois";
+    private static final String GOOGLE_API_URL = "https://maps.googleapis.com/maps/api/place/";
 
     @Value("${security.tmap.app-key}")
-    private String APP_KEY;
-    private static final String API_URL = "https://apis.openapi.sk.com/tmap/pois";
+    private String TMAP_APP_KEY;
+
+    @Value("${security.google.api-key}")
+    private String GOOGLE_API_KEY;
 
     private final PlaceRepository placeRepository;
     private final PlaceReviewRepository placeReviewRepository;
 
-    public List<PlaceInfoResponse> getPlacesByMemberLocation(String searchKeyword, Float latitude, Float longitude) {
-        List<Long> poiIds = getPoiIds(searchKeyword, latitude, longitude);
+    public List<PlaceInfo> getPlacesByLocation(String searchKeyword, Float latitude, Float longitude, Integer page) {
+        List<Long> poiIds = getPoiIds(searchKeyword, latitude, longitude, page);
 
         return poiIds.stream()
                 .map(poiId -> {
@@ -45,7 +51,7 @@ public class PlaceCourseService {
 
                     if (place.isPresent()) {
                         Long reviewCount = placeReviewRepository.countByPlaceId(place.get().getId());
-                        return PlaceConverter.toPlaceInfoResponse(place.get(), reviewCount);
+                        return PlaceConverter.toPlaceInfo(place.get(), reviewCount);
                     }
                     else {
                         return createPlace(poiId);
@@ -53,26 +59,39 @@ public class PlaceCourseService {
                 }).toList();
     }
 
-    private List<Long> getPoiIds(String keyword, Float latitude, Float longitude) {
+    private List<Long> getPoiIds(String keyword, Float latitude, Float longitude, Integer page) {
         try {
             // keyword 인코딩
             String encodedKeyword = URLEncoder.encode(keyword, "UTF-8");
 
             // URL에 쿼리 파라미터 추가
-            String query = String.format(
-                    "?version=1&searchKeyword=%s&searchType=all&searchtypCd=A&centerLon=%f&centerLat=%f" +
-                            "&reqCoordType=WGS84GEO&resCoordType=WGS84GEO&radius=5&page=1&count=20&multiPoint=N&poiGroupYn=N",
-                    encodedKeyword, longitude, latitude
-            );
+            String query;
+
+            // 내 위치 기반 검색(장소만 입력했을 때) - 반경 5km, 거리순
+            if (latitude != null && longitude != null) {
+                query = String.format(
+                        "?version=1&searchKeyword=%s&searchType=all&searchtypCd=R&centerLon=%f&centerLat=%f" +
+                                "&reqCoordType=WGS84GEO&resCoordType=WGS84GEO&radius=5&page=%d&count=10&multiPoint=Y&poiGroupYn=N",
+                        encodedKeyword, longitude, latitude, page
+                );
+            }
+            // 지역 키워드 기반 검색(지역과 장소를 함께 입력)
+            else {
+                query = String.format(
+                        "?version=1&searchKeyword=%s&searchType=all&searchtypCd=A" +
+                                "&reqCoordType=WGS84GEO&resCoordType=WGS84GEO&page=%d&count=10&multiPoint=Y&poiGroupYn=N",
+                        encodedKeyword, page
+                );
+            }
 
             // 연결 설정
-            URL url = new URL(API_URL + query);
+            URL url = new URL(TMAP_API_URL + query);
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
 
             // 헤더 설정
             conn.setRequestMethod("GET");
             conn.setRequestProperty("Accept", "application/json");
-            conn.setRequestProperty("appKey", APP_KEY);
+            conn.setRequestProperty("appKey", TMAP_APP_KEY);
 
             // 응답 처리
             int responseCode = conn.getResponseCode();
@@ -88,11 +107,11 @@ public class PlaceCourseService {
 
                 return parsePoiIds(response.toString());
             } else {
-                throw new RuntimeException("HTTP 응답 코드: " + responseCode);
+                throw new GeneralException(ErrorStatus.SEARCH_PLACE_NOT_FOUND);
             }
 
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -120,12 +139,14 @@ public class PlaceCourseService {
         return poiIds;
     }
 
-    private PlaceInfoResponse createPlace(Long poiId) {
+    private PlaceInfo createPlace(Long poiId) {
         Map<String, String> placeInfo = getPlaceInfo(poiId);
 
         Place place = PlaceConverter.toPlace(placeInfo);
 
-        return PlaceConverter.toPlaceInfoResponse(place, 0L);
+        placeRepository.save(place);
+
+        return PlaceConverter.toPlaceInfo(place, 0L);
     }
 
     private Map<String, String> getPlaceInfo(Long poiId) {
@@ -137,13 +158,13 @@ public class PlaceCourseService {
             );
 
             // 연결 설정
-            URL url = new URL(API_URL + query);
+            URL url = new URL(TMAP_API_URL + query);
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
 
             // 헤더 설정
             conn.setRequestMethod("GET");
             conn.setRequestProperty("Accept", "application/json");
-            conn.setRequestProperty("appKey", APP_KEY);
+            conn.setRequestProperty("appKey", TMAP_APP_KEY);
 
             // 응답 처리
             int responseCode = conn.getResponseCode();
@@ -160,7 +181,7 @@ public class PlaceCourseService {
                 return getPlaceMapByResponse(response.toString());
 
             } else {
-                throw new RuntimeException("HTTP 응답 코드: " + responseCode);
+                throw new RuntimeException("TMAP POI API ERROR: " + responseCode);
             }
 
         } catch (IOException e) {
@@ -181,13 +202,98 @@ public class PlaceCourseService {
         mappedInfo.put("id", poiDetailInfoNode.path("id").asText(null));
         mappedInfo.put("name", poiDetailInfoNode.path("name").asText(null));
         mappedInfo.put("desc", poiDetailInfoNode.path("desc").asText(null));
-        mappedInfo.put("bldAddr", poiDetailInfoNode.path("bldAddr").asText(null));
         mappedInfo.put("address", poiDetailInfoNode.path("address").asText(null));
         mappedInfo.put("lat", poiDetailInfoNode.path("lat").asText(null));
         mappedInfo.put("lon", poiDetailInfoNode.path("lon").asText(null));
         mappedInfo.put("additionalInfo", poiDetailInfoNode.path("additionalInfo").asText(null));
         mappedInfo.put("homepageURL", poiDetailInfoNode.path("homepageURL").asText(null));
 
+        // 도로명 주소 저장
+        String bldNo1 = poiDetailInfoNode.path("bldNo1").asText(null);
+        String bldNo2 = poiDetailInfoNode.path("bldNo2").asText(null);
+
+        String bldNum = bldNo1;
+        if (!bldNo2.isEmpty()) bldNum += "-" + bldNo2;
+
+        mappedInfo.put("bldAddr", poiDetailInfoNode.path("bldAddr").asText(null) + " " + bldNum);
+
+        // 이미지 불러오기
+        String imageUrl = getPlaceImageByName(mappedInfo.get("bldAddr"), mappedInfo.get("name"));
+
+        // 이미지 저장
+        mappedInfo.put("image", imageUrl);
+
         return mappedInfo;
+    }
+
+    private String getPlaceImageByName(String address, String placeName) {
+        try {
+            String searchKeyword = address + " " + placeName;
+            String encodedKeyword = URLEncoder.encode(searchKeyword, "UTF-8");
+
+            // URL에 쿼리 파라미터 추가
+            String query = String.format(
+                    "findplacefromtext/json?fields=photo&input=%s&inputtype=textquery&key=%s",
+                    encodedKeyword, GOOGLE_API_KEY
+            );
+
+            // 연결 설정
+            URL url = new URL(GOOGLE_API_URL + query);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+            // 헤더 설정
+            conn.setRequestMethod("GET");
+
+            // 응답 처리
+            int responseCode = conn.getResponseCode();
+            if (responseCode != HttpURLConnection.HTTP_OK) {
+                throw new RuntimeException("GOOGLE MAP API ERROR: " + responseCode);
+            }
+
+            // 응답 읽기
+            StringBuilder response = new StringBuilder();
+            try (BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream()))) {
+                String inputLine;
+                while ((inputLine = in.readLine()) != null) {
+                    response.append(inputLine);
+                }
+            }
+
+            // Json 파싱 및 thumbnail 값 추출
+            return parsePlaceImageFromJson(response.toString());
+
+        } catch (Exception e) {
+            throw new RuntimeException(e.toString());
+        }
+    }
+
+    private String parsePlaceImageFromJson(String response) throws Exception {
+        if (response == null) throw new RuntimeException("응답이 존재하지 않습니다.");
+
+        // ObjectMapper 초기화
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        // JSON 파싱
+        JsonNode rootNode = objectMapper.readTree(response);
+
+        JsonNode candidates = rootNode.path("candidates");
+
+        // photo_reference 받아오기
+        String photoReference = "";
+
+        for (JsonNode candidate : candidates) {
+            JsonNode photos = candidate.path("photos");
+            for (JsonNode photo : photos) {
+                photoReference = photo.path("photo_reference").asText();
+            }
+        }
+
+        // photo_reference로 photo_url 받아오기
+        String query = String.format(
+                "photo?maxwidth=400&photoreference=%s&key=GOOGLE_API_KEY",
+                photoReference
+        );
+
+        return GOOGLE_API_URL + query;
     }
 }

--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/service/PlaceCourseService.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/service/PlaceCourseService.java
@@ -1,0 +1,191 @@
+package umc.catchy.domain.mapping.placeCourse.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoResponse;
+import umc.catchy.domain.place.converter.PlaceConverter;
+import umc.catchy.domain.place.dao.PlaceRepository;
+import umc.catchy.domain.place.domain.Place;
+import umc.catchy.domain.placeReview.dao.PlaceReviewRepository;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PlaceCourseService {
+
+    private static final String APP_KEY = "yrBgObXPpI1JaoLesS3g79MWrtlSNrkT6xeabWMz";
+    private static final String API_URL = "https://apis.openapi.sk.com/tmap/pois";
+
+    private final PlaceRepository placeRepository;
+    private final PlaceReviewRepository placeReviewRepository;
+
+    public List<PlaceInfoResponse> getPlacesByMemberLocation(String searchKeyword, Float latitude, Float longitude) {
+        List<Long> poiIds = getPoiIds(searchKeyword, latitude, longitude);
+
+        return poiIds.stream()
+                .map(poiId -> {
+                    Optional<Place> place = placeRepository.findByPoiId(poiId);
+
+                    if (place.isPresent()) {
+                        Long reviewCount = placeReviewRepository.countByPlaceId(place.get().getId());
+                        return PlaceConverter.toPlaceInfoResponse(place.get(), reviewCount);
+                    }
+                    else {
+                        return createPlace(poiId);
+                    }
+                }).toList();
+    }
+
+    private List<Long> getPoiIds(String keyword, Float latitude, Float longitude) {
+        try {
+            // keyword 인코딩
+            String encodedKeyword = URLEncoder.encode(keyword, "UTF-8");
+
+            // URL에 쿼리 파라미터 추가
+            String query = String.format(
+                    "?version=1&searchKeyword=%s&searchType=all&searchtypCd=A&centerLon=%f&centerLat=%f" +
+                            "&reqCoordType=WGS84GEO&resCoordType=WGS84GEO&radius=5&page=1&count=20&multiPoint=N&poiGroupYn=N",
+                    encodedKeyword, longitude, latitude
+            );
+
+            // 연결 설정
+            URL url = new URL(API_URL + query);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+            // 헤더 설정
+            conn.setRequestMethod("GET");
+            conn.setRequestProperty("Accept", "application/json");
+            conn.setRequestProperty("appKey", APP_KEY);
+
+            // 응답 처리
+            int responseCode = conn.getResponseCode();
+            if (responseCode == HttpURLConnection.HTTP_OK) {
+                BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+                String inputLine;
+                StringBuilder response = new StringBuilder();
+
+                while ((inputLine = in.readLine()) != null) {
+                    response.append(inputLine);
+                }
+                in.close();
+
+                return parsePoiIds(response.toString());
+            } else {
+                throw new RuntimeException("HTTP 응답 코드: " + responseCode);
+            }
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private List<Long> parsePoiIds(String jsonResponse) throws IOException {
+        // Jackson ObjectMapper 초기화
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        // JSON 파싱
+        JsonNode rootNode = objectMapper.readTree(jsonResponse);
+        JsonNode poisNode = rootNode.path("searchPoiInfo").path("pois").path("poi");
+
+        // ID 리스트 추출
+        List<Long> poiIds = new ArrayList<>();
+        if (poisNode.isArray()) {
+            for (JsonNode poiNode : poisNode) {
+                Long id = Long.parseLong(poiNode.path("id").asText());
+
+                // 중복 방지
+                if (poiIds.contains(id)) continue;
+
+                poiIds.add(id);
+            }
+        }
+
+        return poiIds;
+    }
+
+    private PlaceInfoResponse createPlace(Long poiId) {
+        Map<String, String> placeInfo = getPlaceInfo(poiId);
+
+        Place place = PlaceConverter.toPlace(placeInfo);
+
+        return PlaceConverter.toPlaceInfoResponse(place, 0L);
+    }
+
+    private Map<String, String> getPlaceInfo(Long poiId) {
+        try {
+            // URL에 쿼리 파라미터 추가
+            String query = String.format(
+                    "/%d?version=1&findOption=id&resCoordType=WGS84GEO"
+                    , poiId
+            );
+
+            // 연결 설정
+            URL url = new URL(API_URL + query);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+            // 헤더 설정
+            conn.setRequestMethod("GET");
+            conn.setRequestProperty("Accept", "application/json");
+            conn.setRequestProperty("appKey", APP_KEY);
+
+            // 응답 처리
+            int responseCode = conn.getResponseCode();
+            if (responseCode == HttpURLConnection.HTTP_OK) {
+                BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+                String inputLine;
+                StringBuilder response = new StringBuilder();
+
+                while ((inputLine = in.readLine()) != null) {
+                    response.append(inputLine);
+                }
+                in.close();
+
+                return getPlaceMapByResponse(response.toString());
+
+            } else {
+                throw new RuntimeException("HTTP 응답 코드: " + responseCode);
+            }
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Map<String, String> getPlaceMapByResponse(String response) throws JsonProcessingException {
+        // ObjectMapper 초기화
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        // JSON 파싱
+        JsonNode rootNode = objectMapper.readTree(response);
+        JsonNode poiDetailInfoNode = rootNode.path("poiDetailInfo");
+
+        // Map에 정보 저장
+        Map<String, String> mappedInfo = new HashMap<>();
+        mappedInfo.put("id", poiDetailInfoNode.path("id").asText(null));
+        mappedInfo.put("name", poiDetailInfoNode.path("name").asText(null));
+        mappedInfo.put("desc", poiDetailInfoNode.path("desc").asText(null));
+        mappedInfo.put("bldAddr", poiDetailInfoNode.path("bldAddr").asText(null));
+        mappedInfo.put("address", poiDetailInfoNode.path("address").asText(null));
+        mappedInfo.put("lat", poiDetailInfoNode.path("lat").asText(null));
+        mappedInfo.put("lon", poiDetailInfoNode.path("lon").asText(null));
+        mappedInfo.put("additionalInfo", poiDetailInfoNode.path("additionalInfo").asText(null));
+        mappedInfo.put("homepageURL", poiDetailInfoNode.path("homepageURL").asText(null));
+
+        return mappedInfo;
+    }
+}

--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/service/PlaceCourseService.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/service/PlaceCourseService.java
@@ -82,7 +82,7 @@ public class PlaceCourseService {
                 query = String.format(
                         "?version=1&searchKeyword=%s&searchType=all&searchtypCd=R&centerLon=%f&centerLat=%f" +
                                 "&reqCoordType=WGS84GEO&resCoordType=WGS84GEO&radius=5&page=%d&count=10&multiPoint=Y&poiGroupYn=N",
-                        encodedKeyword, longitude, latitude, page
+                        encodedKeyword, latitude, longitude, page
                 );
             }
             // 지역 키워드 기반 검색(지역과 장소를 함께 입력)

--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/service/PlaceCourseService.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/service/PlaceCourseService.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoResponse;
@@ -28,7 +29,8 @@ import umc.catchy.domain.placeReview.dao.PlaceReviewRepository;
 @RequiredArgsConstructor
 public class PlaceCourseService {
 
-    private static final String APP_KEY = "yrBgObXPpI1JaoLesS3g79MWrtlSNrkT6xeabWMz";
+    @Value("${security.tmap.app-key}")
+    private String APP_KEY;
     private static final String API_URL = "https://apis.openapi.sk.com/tmap/pois";
 
     private final PlaceRepository placeRepository;

--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/service/PlaceCourseService.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/service/PlaceCourseService.java
@@ -43,7 +43,7 @@ public class PlaceCourseService {
     private final PlaceRepository placeRepository;
     private final PlaceReviewRepository placeReviewRepository;
 
-    public List<PlaceInfo> getPlacesByLocation(String searchKeyword, Float latitude, Float longitude, Integer page) {
+    public List<PlaceInfo> getPlacesByLocation(String searchKeyword, Double latitude, Double longitude, Integer page) {
         List<Long> poiIds = getPoiIds(searchKeyword, latitude, longitude, page);
 
         return poiIds.stream()
@@ -69,7 +69,7 @@ public class PlaceCourseService {
         return PlaceConverter.toPlaceInfoDetail(place, reviewCount);
     }
 
-    private List<Long> getPoiIds(String keyword, Float latitude, Float longitude, Integer page) {
+    private List<Long> getPoiIds(String keyword, Double latitude, Double longitude, Integer page) {
         try {
             // keyword 인코딩
             String encodedKeyword = URLEncoder.encode(keyword, "UTF-8");

--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/service/PlaceCourseService.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/service/PlaceCourseService.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfo;
+import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoDetail;
 import umc.catchy.domain.place.converter.PlaceConverter;
 import umc.catchy.domain.place.dao.PlaceRepository;
 import umc.catchy.domain.place.domain.Place;
@@ -57,6 +58,15 @@ public class PlaceCourseService {
                         return createPlace(poiId);
                     }
                 }).toList();
+    }
+
+    public PlaceInfoDetail getPlaceDetailByPlaceId(Long placeId) {
+        Place place = placeRepository.findById(placeId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.PLACE_NOT_FOUND));
+
+        Long reviewCount = placeReviewRepository.countByPlaceId(placeId);
+
+        return PlaceConverter.toPlaceInfoDetail(place, reviewCount);
     }
 
     private List<Long> getPoiIds(String keyword, Float latitude, Float longitude, Integer page) {

--- a/src/main/java/umc/catchy/domain/member/dto/response/SignUpResponse.java
+++ b/src/main/java/umc/catchy/domain/member/dto/response/SignUpResponse.java
@@ -9,7 +9,9 @@ public record SignUpResponse(
         String email,
         String nickname,
         String profileImage,
-        LocalDateTime createdDate
+        LocalDateTime createdDate,
+        String accessToken,
+        String refreshToken
 ) {
     public static SignUpResponse of(Member member) {
         return new SignUpResponse(
@@ -18,7 +20,9 @@ public record SignUpResponse(
                 member.getEmail(),
                 member.getNickname(),
                 member.getProfileImage(),
-                member.getCreatedDate()
+                member.getCreatedDate(),
+                member.getAccessToken(),
+                member.getRefreshToken()
         );
     }
 

--- a/src/main/java/umc/catchy/domain/place/converter/PlaceConverter.java
+++ b/src/main/java/umc/catchy/domain/place/converter/PlaceConverter.java
@@ -1,6 +1,8 @@
 package umc.catchy.domain.place.converter;
 
+import java.util.Map;
 import umc.catchy.domain.course.dto.response.CourseInfoResponse;
+import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoResponse;
 import umc.catchy.domain.place.domain.Place;
 
 public class PlaceConverter {
@@ -13,6 +15,41 @@ public class PlaceConverter {
                 .placeLatitude(place.getLatitude())
                 .placeLongitude(place.getLongitude())
                 .isVisited(isVisited)
+                .build();
+    }
+
+    public static PlaceInfoResponse toPlaceInfoResponse(Place place, Long reviewCount) {
+        String categoryName = "";
+
+        if (place.getCategory() != null) {
+            categoryName = place.getCategory().getName();
+        }
+
+        return PlaceInfoResponse.builder()
+                .placeId(place.getId())
+                .imageUrl(place.getImageUrl())
+                .placeName(place.getPlaceName())
+                .placeDescription(place.getPlaceDescription())
+                .category(categoryName)
+                .roadAddress(place.getRoadAddress())
+                .activeTime(place.getActiveTime())
+                .rating(place.getRating())
+                .reviewCount(reviewCount)
+                .placeSite(place.getPlaceSite())
+                .build();
+    }
+
+    public static Place toPlace(Map<String, String> placeInfo) {
+        return Place.builder()
+                .poiId(Long.parseLong(placeInfo.get("id")))
+                .placeName(placeInfo.get("name"))
+                .placeDescription(placeInfo.get("desc"))
+                .roadAddress(placeInfo.get("bldAddr"))
+                .numberAddress(placeInfo.get("address"))
+                .latitude(Double.parseDouble(placeInfo.get("lat")))
+                .longitude(Double.parseDouble(placeInfo.get("lon")))
+                .activeTime(placeInfo.get("additionalInfo"))
+                .placeSite(placeInfo.get("homepageURL"))
                 .build();
     }
 }

--- a/src/main/java/umc/catchy/domain/place/converter/PlaceConverter.java
+++ b/src/main/java/umc/catchy/domain/place/converter/PlaceConverter.java
@@ -2,7 +2,8 @@ package umc.catchy.domain.place.converter;
 
 import java.util.Map;
 import umc.catchy.domain.course.dto.response.CourseInfoResponse;
-import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoResponse;
+import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfo;
+import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoDetail;
 import umc.catchy.domain.place.domain.Place;
 
 public class PlaceConverter {
@@ -18,7 +19,7 @@ public class PlaceConverter {
                 .build();
     }
 
-    public static PlaceInfoResponse toPlaceInfoResponse(Place place, Long reviewCount) {
+    public static PlaceInfo toPlaceInfo(Place place, Long reviewCount) {
         String categoryName = "";
         Double rating = 0.0;
 
@@ -30,18 +31,15 @@ public class PlaceConverter {
             rating = place.getRating();
         }
 
-        return PlaceInfoResponse.builder()
+        return PlaceInfo.builder()
                 .placeId(place.getId())
                 .poiId(place.getPoiId())
-                .imageUrl(place.getImageUrl())
                 .placeName(place.getPlaceName())
-                .placeDescription(place.getPlaceDescription())
                 .category(categoryName)
                 .roadAddress(place.getRoadAddress())
                 .activeTime(place.getActiveTime())
                 .rating(rating)
                 .reviewCount(reviewCount)
-                .placeSite(place.getPlaceSite())
                 .build();
     }
 
@@ -49,6 +47,7 @@ public class PlaceConverter {
         return Place.builder()
                 .poiId(Long.parseLong(placeInfo.get("id")))
                 .placeName(placeInfo.get("name"))
+                .imageUrl(placeInfo.get("image"))
                 .placeDescription(placeInfo.get("desc"))
                 .roadAddress(placeInfo.get("bldAddr"))
                 .numberAddress(placeInfo.get("address"))

--- a/src/main/java/umc/catchy/domain/place/converter/PlaceConverter.java
+++ b/src/main/java/umc/catchy/domain/place/converter/PlaceConverter.java
@@ -43,6 +43,33 @@ public class PlaceConverter {
                 .build();
     }
 
+    public static PlaceInfoDetail toPlaceInfoDetail(Place place, Long reviewCount) {
+        String categoryName = "";
+        Double rating = 0.0;
+
+        if (place.getCategory() != null) {
+            categoryName = place.getCategory().getName();
+        }
+
+        if (place.getRating() != null) {
+            rating = place.getRating();
+        }
+
+        return PlaceInfoDetail.builder()
+                .placeId(place.getId())
+                .poiId(place.getPoiId())
+                .imageUrl(place.getImageUrl())
+                .placeName(place.getPlaceName())
+                .placeDescription(place.getPlaceDescription())
+                .category(categoryName)
+                .roadAddress(place.getRoadAddress())
+                .activeTime(place.getActiveTime())
+                .placeSite(place.getPlaceSite())
+                .rating(rating)
+                .reviewCount(reviewCount)
+                .build();
+    }
+
     public static Place toPlace(Map<String, String> placeInfo) {
         return Place.builder()
                 .poiId(Long.parseLong(placeInfo.get("id")))

--- a/src/main/java/umc/catchy/domain/place/converter/PlaceConverter.java
+++ b/src/main/java/umc/catchy/domain/place/converter/PlaceConverter.java
@@ -20,20 +20,26 @@ public class PlaceConverter {
 
     public static PlaceInfoResponse toPlaceInfoResponse(Place place, Long reviewCount) {
         String categoryName = "";
+        Double rating = 0.0;
 
         if (place.getCategory() != null) {
             categoryName = place.getCategory().getName();
         }
 
+        if (place.getRating() != null) {
+            rating = place.getRating();
+        }
+
         return PlaceInfoResponse.builder()
                 .placeId(place.getId())
+                .poiId(place.getPoiId())
                 .imageUrl(place.getImageUrl())
                 .placeName(place.getPlaceName())
                 .placeDescription(place.getPlaceDescription())
                 .category(categoryName)
                 .roadAddress(place.getRoadAddress())
                 .activeTime(place.getActiveTime())
-                .rating(place.getRating())
+                .rating(rating)
                 .reviewCount(reviewCount)
                 .placeSite(place.getPlaceSite())
                 .build();

--- a/src/main/java/umc/catchy/domain/place/converter/PlaceConverter.java
+++ b/src/main/java/umc/catchy/domain/place/converter/PlaceConverter.java
@@ -82,6 +82,7 @@ public class PlaceConverter {
                 .longitude(Double.parseDouble(placeInfo.get("lon")))
                 .activeTime(placeInfo.get("additionalInfo"))
                 .placeSite(placeInfo.get("homepageURL"))
+                .rating(0.0)
                 .build();
     }
 }

--- a/src/main/java/umc/catchy/domain/place/dao/PlaceRepository.java
+++ b/src/main/java/umc/catchy/domain/place/dao/PlaceRepository.java
@@ -1,5 +1,6 @@
 package umc.catchy.domain.place.dao;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,4 +14,6 @@ import java.util.List;
 public interface PlaceRepository extends JpaRepository<Place, Long> {
     @Query("SELECT p FROM Place p WHERE p.category.bigCategory = :bigCategory AND p.roadAddress LIKE %:groupLocation%")
     List<Place> findByBigCategoryAndLocation(@Param("bigCategory") BigCategory bigCategory, @Param("groupLocation") String groupLocation);
+
+    Optional<Place> findByPoiId(Long poiId);
 }

--- a/src/main/java/umc/catchy/domain/place/domain/Place.java
+++ b/src/main/java/umc/catchy/domain/place/domain/Place.java
@@ -1,18 +1,26 @@
 package umc.catchy.domain.place.domain;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import umc.catchy.domain.category.domain.Category;
 import umc.catchy.domain.common.BaseTimeEntity;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Place extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "place_id")
     private Long id;
+
+    private Long poiId;
 
     private String placeName;
 

--- a/src/main/java/umc/catchy/domain/place/domain/Place.java
+++ b/src/main/java/umc/catchy/domain/place/domain/Place.java
@@ -24,6 +24,7 @@ public class Place extends BaseTimeEntity {
 
     private String placeName;
 
+    @Column(length = 50000)
     private String placeDescription;
 
     private String roadAddress; //도로명 주소

--- a/src/main/java/umc/catchy/domain/place/domain/Place.java
+++ b/src/main/java/umc/catchy/domain/place/domain/Place.java
@@ -38,6 +38,7 @@ public class Place extends BaseTimeEntity {
 
     private String placeSite; // 장소 사이트
 
+    @Column(length = 50000)
     private String imageUrl; // 장소 이미지
 
     @Setter

--- a/src/main/java/umc/catchy/global/common/response/status/ErrorStatus.java
+++ b/src/main/java/umc/catchy/global/common/response/status/ErrorStatus.java
@@ -30,6 +30,7 @@ public enum ErrorStatus implements BaseErrorCode {
     //장소 관련 에러
     PLACE_REVIEW_INVALID_MEMBER(HttpStatus.BAD_REQUEST, "PLACE_REVIEW_MEMBER400", "해당 멤버는 장소 리뷰를 달 수 있는 권한이 없습니다."),
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE404", "해당 장소를 찾을 수 없습니다."),
+    SEARCH_PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "SEARCH_PLACE404", "찾는 장소가 없습니다."),
 
     //코스 관련 에러
     COURSE_REVIEW_INVALID_MEMBER(HttpStatus.BAD_REQUEST, "COURSE_REVIEW_MEMBER400", "해당 멤버는 코스 리뷰를 달 수 있는 권한이 없습니다."),

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -37,6 +37,8 @@ security:
   kakao:
     client-id: ${KAKAO_CLIENT_ID}
     client-secret: ${KAKAO_CLIENT_PRIVATE_ID}
+  tmap:
+    app-key: ${TMAP_APP_KEY}
 
 server:
   port: 8081


### PR DESCRIPTION
## 📌 Issue Number

- close #76 

## 🪐 작업 내용

- 사용자 위치 기반 장소 검색

## ✅ PR 상세 내용

- 사용자 위치 기반 장소 검색
  - 사용자의 위도, 경도, 검색 키워드를 통해 장소 정보를 받아온다 
  - 예를 들어, 스타벅스를 검색하면 내 위치 반경 5km 이내의 스타벅스를 거리순으로 정렬

- 지역 기반 장소 검색
  -  사용자의 검색 키워드를 통해 장소 정보를 받아온다
  - 예를 들어, 서울시 동작구 스타벅스를 검색하면 관련도 높은 순으로 정렬

- 장소 이미지 저장 로직
  - TMAP에서 받아온 장소의 주소와 가게 이름 정보를 통해 구글 맵 API로 GET 요청을 하여 가게를 찾음
  - 해당 response에서 받아온 photo_reference 값을 구글 맵 API에 GET 요청을 하여 이미지를 받아옴
  - url에는 API KEY 값이 포함되어 GOOGLE_API_KEY로 치환하여 저장하였음
  - 프론트에서는 GOOGLE_API_KEY를 실제 앱 키로 바꾸어 이미지를 가져올 것임

- 장소 저장 로직 설명
1. 사용자가 장소를 검색 
2. TMAP에서 관련 장소를 모두 불러옴
3. 그 장소 리스트를 스트림으로 검사해서 PlaceRepository에 있는지 검사(findByPoiId)
4. 있으면 그 장소 데이터를 가져오고
5. 없으면 TMAP에서 제공해준 Place 정보와 구글에서 해당 장소의 이미지를 가져와 Place를 저장.

## 📸 스크린샷(선택)

- 지역명 기반 검색 결과: 서울시 동작구 스타벅스
<img width="321" alt="image" src="https://github.com/user-attachments/assets/fa0a2ed8-3b28-4af4-a942-9abf2b0ae0dd" />

- 내 위치 기반 검색 결과: 서울시 강남구 위치에서 '고기' 검색
<img width="351" alt="image" src="https://github.com/user-attachments/assets/7e178b74-cfc0-477f-b269-cf8e21f1f666" />

- placeId로 placeDetail 불러오기
<img width="894" alt="image" src="https://github.com/user-attachments/assets/6e28ae51-d539-4fa3-bb11-e5e6b88deabc" />

## 

- TMAP api에서 페이지 별로 장소를 받을 수 있어서 page를 parameter로 추가함 
- 로컬 테스트시, 환경변수 설정 필요(TMAP_APP_KEY) 
- 장소 이미지를 보려면 db에 저장된 url에 GOOGLE_API_KEY 값을 넣으면됨

## ❌ 애로 사항

- API 호출 poiId 받아오기 -> poiId로 상세정보 받아오기 -> 상세정보로 이미지 받아오기
- 총 3번으로 이루어져서 db에 저장안된 새로운 장소라면 검색이 오래걸리는 것이 문제...

## 📚 Reference

