### PR TITLE
[feature] 좋아요한 장소 조회

### DIFF
--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/api/PlaceCourseController.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/api/PlaceCourseController.java
@@ -1,0 +1,26 @@
+package umc.catchy.domain.mapping.placeCourse.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoResponse;
+import umc.catchy.domain.mapping.placeCourse.service.PlaceCourseService;
+import umc.catchy.global.common.response.BaseResponse;
+import umc.catchy.global.common.response.status.SuccessStatus;
+
+@RestController
+@RequiredArgsConstructor
+public class PlaceCourseController {
+    private final PlaceCourseService placeCourseService;
+
+    @Operation(summary = "좋아요한 장소 무한 스크롤 API", description = "좋아요한 장소 정보들을 무한 스크롤로 보여줍니다.")
+    @GetMapping("/mypage/like")
+    public BaseResponse<Slice<PlaceInfoResponse>> findAllCourseByBookmarked(@RequestParam int pageSize,
+                                                                            @RequestParam(required = false) Long lastPlaceId) {
+        Slice<PlaceInfoResponse> response = placeCourseService.searchLikedPlace(pageSize, lastPlaceId);
+        return BaseResponse.onSuccess(SuccessStatus._OK,response);
+    }
+}

--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/dao/PlaceCourseRepository.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/dao/PlaceCourseRepository.java
@@ -11,7 +11,7 @@ import umc.catchy.domain.place.domain.Place;
 import java.util.List;
 
 @Repository
-public interface PlaceCourseRepository extends JpaRepository<PlaceCourse, Long> {
+public interface PlaceCourseRepository extends JpaRepository<PlaceCourse, Long>, PlaceCourseRepositoryCustom {
     List<PlaceCourse> findAllByCourse(Course course);
     List<PlaceCourse> findAllByPlace(Place place);
 

--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/dao/PlaceCourseRepositoryCustom.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/dao/PlaceCourseRepositoryCustom.java
@@ -1,0 +1,8 @@
+package umc.catchy.domain.mapping.placeCourse.dao;
+
+import org.springframework.data.domain.Slice;
+import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoResponse;
+
+public interface PlaceCourseRepositoryCustom {
+    Slice<PlaceInfoResponse> searchPlaceByLiked(Long memberId, int pageSize, Long lastPlaceId);
+}

--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/dao/PlaceCourseRepositoryImpl.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/dao/PlaceCourseRepositoryImpl.java
@@ -1,0 +1,76 @@
+package umc.catchy.domain.mapping.placeCourse.dao;
+
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoResponse;
+
+
+import java.util.List;
+
+import static umc.catchy.domain.mapping.placeVisit.domain.QPlaceVisit.placeVisit;
+import static umc.catchy.domain.member.domain.QMember.member;
+import static umc.catchy.domain.place.domain.QPlace.*;
+import static umc.catchy.domain.placeReview.domain.QPlaceReview.placeReview;
+
+@RequiredArgsConstructor
+public class PlaceCourseRepositoryImpl implements PlaceCourseRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<PlaceInfoResponse> searchPlaceByLiked(Long memberId, int pageSize, Long lastPlaceId) {
+        List<PlaceInfoResponse> results = queryFactory.select(Projections.fields(PlaceInfoResponse.class,
+                        place.id.as("placeId"),
+                        place.imageUrl.as("imageUrl"),
+                        place.placeName.as("placeName"),
+                        place.placeDescription.as("placeDescription"),
+                        place.category.name.as("categoryName"),
+                        place.roadAddress.as("roadAddress"),
+                        place.activeTime.as("activeTime"),
+                        placeReview.rating.avg().as("rating"),
+                        placeReview.count().as("reviewCount"),
+                        null
+                        ))
+                .from(placeVisit)
+                .leftJoin(placeVisit.place, place).on(placeVisit.place.id.eq(place.id)).fetchJoin()
+                .leftJoin(placeVisit.member, member).on(placeVisit.member.id.eq(member.id)).fetchJoin()
+                .leftJoin(placeReview).on(placeReview.place.id.eq(place.id))
+                .where(
+                        placeVisit.member.id.eq(memberId),
+                        lastPlaceId(lastPlaceId),
+                        likedCondition
+                )
+                .groupBy(place.id)
+                .orderBy(placeVisit.place.createdDate.desc())
+                .limit(pageSize + 1)
+                .fetch();
+
+        return checkLastPage(pageSize,results);
+    }
+
+    private BooleanExpression likedCondition = placeVisit.isLiked.eq(true);
+
+    private BooleanExpression lastPlaceId(Long placeId) {
+        if (placeId == null) {
+            return null;
+        }
+        return place.id.lt(placeId);
+    }
+
+    private Slice<PlaceInfoResponse> checkLastPage(int pageSize, List<PlaceInfoResponse> results) {
+        boolean hasNext = false;
+
+        if (results.size() > pageSize) {
+            hasNext = true;
+            results.remove(pageSize);
+        }
+
+        return new SliceImpl<>(results, PageRequest.of(0,pageSize), hasNext);
+    }
+}

--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/dao/PlaceCourseRepositoryImpl.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/dao/PlaceCourseRepositoryImpl.java
@@ -34,12 +34,11 @@ public class PlaceCourseRepositoryImpl implements PlaceCourseRepositoryCustom{
                         place.roadAddress.as("roadAddress"),
                         place.activeTime.as("activeTime"),
                         placeReview.rating.avg().as("rating"),
-                        placeReview.count().as("reviewCount"),
-                        null
+                        placeReview.count().as("reviewCount")
                         ))
                 .from(placeVisit)
-                .leftJoin(placeVisit.place, place).on(placeVisit.place.id.eq(place.id)).fetchJoin()
-                .leftJoin(placeVisit.member, member).on(placeVisit.member.id.eq(member.id)).fetchJoin()
+                .leftJoin(placeVisit.place, place).on(placeVisit.place.id.eq(place.id))
+                .leftJoin(placeVisit.member, member).on(placeVisit.member.id.eq(member.id))
                 .leftJoin(placeReview).on(placeReview.place.id.eq(place.id))
                 .where(
                         placeVisit.member.id.eq(memberId),

--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/dto/response/PlaceInfoResponse.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/dto/response/PlaceInfoResponse.java
@@ -4,7 +4,7 @@ import lombok.*;
 
 @Getter
 @Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @AllArgsConstructor
 public class PlaceInfoResponse {
     private Long placeId;

--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/dto/response/PlaceInfoResponse.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/dto/response/PlaceInfoResponse.java
@@ -1,0 +1,21 @@
+package umc.catchy.domain.mapping.placeCourse.dto.response;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PlaceInfoResponse {
+    private Long placeId;
+    private String imageUrl;
+    private String placeName;
+    private String placeDescription;
+    private String categoryName;
+    private String roadAddress;
+    private String activeTime;
+    private Double rating;
+    private Long reviewCount;
+    private String placeSite;
+
+}

--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/service/PlaceCourseService.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/service/PlaceCourseService.java
@@ -21,7 +21,6 @@ public class PlaceCourseService {
 
     public Slice<PlaceInfoResponse> searchLikedPlace(int pageSize, Long lastPlaceId) {
         Long memberId = SecurityUtil.getCurrentMemberId();
-        Member currentMember = memberRepository.findById(memberId).orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
-        return placeCourseRepository.searchPlaceByLiked(currentMember.getId(), pageSize, lastPlaceId);
+        return placeCourseRepository.searchPlaceByLiked(memberId, pageSize, lastPlaceId);
     }
 }

--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/service/PlaceCourseService.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/service/PlaceCourseService.java
@@ -1,0 +1,27 @@
+package umc.catchy.domain.mapping.placeCourse.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import umc.catchy.domain.mapping.placeCourse.dao.PlaceCourseRepository;
+import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoResponse;
+import umc.catchy.domain.member.dao.MemberRepository;
+import umc.catchy.domain.member.domain.Member;
+import umc.catchy.global.common.response.status.ErrorStatus;
+import umc.catchy.global.error.exception.GeneralException;
+import umc.catchy.global.util.SecurityUtil;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PlaceCourseService {
+    private final PlaceCourseRepository placeCourseRepository;
+    private final MemberRepository memberRepository;
+
+    public Slice<PlaceInfoResponse> searchLikedPlace(int pageSize, Long lastPlaceId) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        Member currentMember = memberRepository.findById(memberId).orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+        return placeCourseRepository.searchPlaceByLiked(currentMember.getId(), pageSize, lastPlaceId);
+    }
+}


### PR DESCRIPTION
## 📌 Issue Number

- close #71 

## 🪐 작업 내용

- 좋아요한 장소 조회 무한 스크롤 

## ✅ PR 상세 내용

- querydsl을 적용해 좋아요한 장소들을 무한 스크롤 형태로 구현했다.

## 📸 스크린샷(선택)

- 성공 시 다음과 같이 나옴
<img width="361" alt="image" src="https://github.com/user-attachments/assets/48804c06-8cee-4eeb-9bac-07e9689915df" />


## ❌ 애로 사항

- fetch join을 통해 n+1문제를 해결하려고 했으나 에러가 발생해 groupby를 통해 리뷰의 평점 평균, 리뷰 개수를 구했다. 
- 여러개의 엔티티간 조인이 있어서 어려움이 있었다.

## 📚 Reference

- https://breakcoding.tistory.com/407
