### PR TITLE
[fix] 리뷰 작성 : 방문 날짜 로직 수정

### DIFF
--- a/src/main/java/umc/catchy/domain/courseReview/converter/CourseReviewConverter.java
+++ b/src/main/java/umc/catchy/domain/courseReview/converter/CourseReviewConverter.java
@@ -13,14 +13,12 @@ public class CourseReviewConverter {
 
     public static PostCourseReviewResponse.newCourseReviewResponseDTO toNewCourseReviewResponseDTO(
             CourseReview courseReview,
-            List<PostCourseReviewResponse.courseReviewImageResponseDTO> images,
-            LocalDateTime visitedDate
+            List<PostCourseReviewResponse.courseReviewImageResponseDTO> images
     ){
         return PostCourseReviewResponse.newCourseReviewResponseDTO.builder()
                 .reviewId(courseReview.getId())
                 .comment(courseReview.getComment())
                 .reviewImages(images)
-                .visitedDate(visitedDate)
                 .creatorNickname(courseReview.getMember().getNickname())
                 .build();
     }

--- a/src/main/java/umc/catchy/domain/courseReview/dto/response/PostCourseReviewResponse.java
+++ b/src/main/java/umc/catchy/domain/courseReview/dto/response/PostCourseReviewResponse.java
@@ -18,7 +18,7 @@ public class PostCourseReviewResponse {
         Long reviewId;
         String comment;
         List<courseReviewImageResponseDTO> reviewImages;
-        LocalDateTime visitedDate;
+        //LocalDateTime visitedDate;
         String creatorNickname;
     }
 

--- a/src/main/java/umc/catchy/domain/courseReview/service/CourseReviewService.java
+++ b/src/main/java/umc/catchy/domain/courseReview/service/CourseReviewService.java
@@ -58,10 +58,7 @@ public class CourseReviewService {
         }
 
         //코스 참여일자 가져오기
-        LocalDateTime visitedDate = memberCourseRepository.findByCourseAndMember(course, member)
-                .map(MemberCourse::getVisitedDate)
-                .orElse(null);
-
+        
         //CourseReview Entity 생성 및 저장
         CourseReview newCourseReview = CourseReviewConverter.toCourseReview(member, course, request);
         courseReviewRepository.save(newCourseReview);
@@ -82,6 +79,6 @@ public class CourseReviewService {
             courseReviewImageRepository.save(courseReviewImage);
             images.add(CourseReviewImageConverter.toCourseReviewImageResponseDTO(courseReviewImage));
         }
-        return CourseReviewConverter.toNewCourseReviewResponseDTO(newCourseReview, images, visitedDate);
+        return CourseReviewConverter.toNewCourseReviewResponseDTO(newCourseReview, images);
     }
 }

--- a/src/main/java/umc/catchy/domain/placeReview/converter/PlaceReviewConverter.java
+++ b/src/main/java/umc/catchy/domain/placeReview/converter/PlaceReviewConverter.java
@@ -6,18 +6,18 @@ import umc.catchy.domain.placeReview.domain.PlaceReview;
 import umc.catchy.domain.placeReview.dto.request.PostPlaceReviewRequest;
 import umc.catchy.domain.placeReview.dto.response.PostPlaceReviewResponse;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 public class PlaceReviewConverter {
 
-    public static PostPlaceReviewResponse.newPlaceReviewResponseDTO toNewPlaceReviewResponseDTO(PlaceReview placeReview, List<PostPlaceReviewResponse.placeReviewImageResponseDTO> images, LocalDateTime visitedDate) {
+    public static PostPlaceReviewResponse.newPlaceReviewResponseDTO toNewPlaceReviewResponseDTO(PlaceReview placeReview, List<PostPlaceReviewResponse.placeReviewImageResponseDTO> images) {
         return PostPlaceReviewResponse.newPlaceReviewResponseDTO.builder()
                 .reviewId(placeReview.getId())
                 .comment(placeReview.getComment())
                 .rating(placeReview.getRating())
                 .reviewImages(images)
-                .visitedDate(visitedDate)
+                .visitedDate(placeReview.getVisitedDate())
                 .creatorNickname(placeReview.getMember().getNickname())
                 .build();
     }
@@ -26,6 +26,7 @@ public class PlaceReviewConverter {
         return PlaceReview.builder()
                 .comment(request.getComment())
                 .rating(request.getRating())
+                .visitedDate(request.getVisitedDate())
                 .member(member)
                 .place(place)
                 .build();

--- a/src/main/java/umc/catchy/domain/placeReview/domain/PlaceReview.java
+++ b/src/main/java/umc/catchy/domain/placeReview/domain/PlaceReview.java
@@ -6,6 +6,8 @@ import umc.catchy.domain.common.BaseTimeEntity;
 import umc.catchy.domain.member.domain.Member;
 import umc.catchy.domain.place.domain.Place;
 
+import java.time.LocalDate;
+
 @Entity
 @Getter
 @Builder
@@ -20,6 +22,8 @@ public class PlaceReview extends BaseTimeEntity {
     private Integer rating;
 
     private String comment;
+
+    private LocalDate visitedDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/umc/catchy/domain/placeReview/dto/request/PostPlaceReviewRequest.java
+++ b/src/main/java/umc/catchy/domain/placeReview/dto/request/PostPlaceReviewRequest.java
@@ -1,15 +1,12 @@
 package umc.catchy.domain.placeReview.dto.request;
 
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.http.MediaType;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Getter
@@ -25,6 +22,9 @@ public class PostPlaceReviewRequest {
     @NotBlank
     @Size(max = 300, message = "최대 300자까지 입력 가능합니다.")
     String comment;
+
+    @NotNull(message = "방문날짜를 입력해주세요/YY-MM-DD")
+    LocalDate visitedDate;
 
     @Size(max = 5, message = "이미지는 최대 5개까지만 업로드 가능합니다.")
     List<MultipartFile> images;

--- a/src/main/java/umc/catchy/domain/placeReview/dto/response/PostPlaceReviewResponse.java
+++ b/src/main/java/umc/catchy/domain/placeReview/dto/response/PostPlaceReviewResponse.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 public class PostPlaceReviewResponse {
@@ -19,7 +19,7 @@ public class PostPlaceReviewResponse {
         Integer rating;
         String comment;
         List<placeReviewImageResponseDTO> reviewImages;
-        LocalDateTime visitedDate;
+        LocalDate visitedDate;
         String creatorNickname;
     }
 

--- a/src/main/java/umc/catchy/domain/placeReview/service/PlaceReviewService.java
+++ b/src/main/java/umc/catchy/domain/placeReview/service/PlaceReviewService.java
@@ -87,11 +87,6 @@ public class PlaceReviewService {
             throw new GeneralException(ErrorStatus.PLACE_REVIEW_INVALID_MEMBER);
         }
 
-        //장소 방문일자 가져오기
-        LocalDateTime visitedDate = placeVisitRepository.findByPlaceAndMember(place, member)
-                .map(PlaceVisit::getVisitedDate)
-                .orElse(null);
-
         //PlaceReview 엔티티 생성 및 저장
         PlaceReview newPlaceReview = PlaceReviewConverter.toPlaceReview(member, place, request);
         placeReviewRepository.save(newPlaceReview);
@@ -109,6 +104,6 @@ public class PlaceReviewService {
             placeReviewImageRepository.save(placeReviewImage);
             reviewImages.add(PlaceReviewImageConverter.toPlaceReviewImageResponseDTO(placeReviewImage));
         }
-        return PlaceReviewConverter.toNewPlaceReviewResponseDTO(newPlaceReview, reviewImages, visitedDate);
+        return PlaceReviewConverter.toNewPlaceReviewResponseDTO(newPlaceReview, reviewImages);
     }
 }


### PR DESCRIPTION
## 📌 Issue Number

- close #135 

## 🪐 작업 내용

- 리뷰 작성 시, 방문 날짜를 가져오는 방식 수정

## ✅ PR 상세 내용

- 코스 리뷰 : visitedDate 관련 로직 delete
- 장소 리뷰 : request로 visitedDate를 받고 이를 PlaceReview에 저장

## 📸 스크린샷(선택)
1. 코스 리뷰
![image](https://github.com/user-attachments/assets/3e4b6e16-3e31-4ab1-a321-e27e0c026bdc)

2. 장소 리뷰
![image](https://github.com/user-attachments/assets/454fba13-4ea6-4e14-bce5-893066c62b44)
![image](https://github.com/user-attachments/assets/4f59c958-eeef-4b8e-89d4-c1175f9ebd65)


## ❌ 애로 사항

- 인기 코스 조회 시 넣어놨던 데이터 중 memberCourse에 member와 course가 중복되는 데이터가 있어서 Query did not return a unique result: 2 results were returned 에러가 발생 => 데이터를 지워서 해결함.

## 📚 Reference
