### PR TITLE
[feat] 리뷰 신고/삭제 API

### DIFF
--- a/src/main/java/umc/catchy/domain/courseReviewImage/dao/CourseReviewImageRepository.java
+++ b/src/main/java/umc/catchy/domain/courseReviewImage/dao/CourseReviewImageRepository.java
@@ -2,8 +2,13 @@ package umc.catchy.domain.courseReviewImage.dao;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import umc.catchy.domain.courseReview.domain.CourseReview;
 import umc.catchy.domain.courseReviewImage.domain.CourseReviewImage;
+
+import java.util.List;
 
 @Repository
 public interface CourseReviewImageRepository extends JpaRepository<CourseReviewImage, Long> {
+    void deleteAllByCourseReview(CourseReview courseReview);
+    List<CourseReviewImage> findAllByCourseReview(CourseReview courseReview);
 }

--- a/src/main/java/umc/catchy/domain/placeReviewImage/dao/PlaceReviewImageRepository.java
+++ b/src/main/java/umc/catchy/domain/placeReviewImage/dao/PlaceReviewImageRepository.java
@@ -2,8 +2,13 @@ package umc.catchy.domain.placeReviewImage.dao;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import umc.catchy.domain.placeReview.domain.PlaceReview;
 import umc.catchy.domain.placeReviewImage.domain.PlaceReviewImage;
+
+import java.util.List;
 
 @Repository
 public interface PlaceReviewImageRepository extends JpaRepository<PlaceReviewImage, Long> {
+    void deleteAllByPlaceReview(PlaceReview placeReview);
+    List<PlaceReviewImage> findAllByPlaceReview(PlaceReview placeReview);
 }

--- a/src/main/java/umc/catchy/domain/reviewReport/api/ReviewReportController.java
+++ b/src/main/java/umc/catchy/domain/reviewReport/api/ReviewReportController.java
@@ -28,7 +28,6 @@ public class ReviewReportController {
         return ResponseEntity.ok(BaseResponse.onSuccess(SuccessStatus._OK, response));
     }
 
-    //TODO 리뷰 삭제하기
     @Operation(summary = "리뷰 삭제 API", description = "코스리뷰, 장소리뷰 통합 리뷰 삭제 API입니다.")
     @DeleteMapping("/mypage/reviews/{reviewId}")
     public ResponseEntity<BaseResponse<DeleteReviewResponse>> deleteReview(

--- a/src/main/java/umc/catchy/domain/reviewReport/api/ReviewReportController.java
+++ b/src/main/java/umc/catchy/domain/reviewReport/api/ReviewReportController.java
@@ -1,0 +1,34 @@
+package umc.catchy.domain.reviewReport.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import umc.catchy.domain.reviewReport.dto.request.PostReviewReportRequest;
+import umc.catchy.domain.reviewReport.dto.response.PostReviewReportResponse;
+import umc.catchy.domain.reviewReport.service.ReviewReportService;
+import umc.catchy.global.common.response.BaseResponse;
+import umc.catchy.global.common.response.status.SuccessStatus;
+
+@RestController
+@RequiredArgsConstructor
+public class ReviewReportController {
+
+    private final ReviewReportService reviewReportService;
+
+    @Operation(summary = "리뷰 신고 API", description = "코스 리뷰, 장소 리뷰 통합 리뷰 신고 API입니다.")
+    @PostMapping("/reviews/{reviewId}/report")
+    public ResponseEntity<BaseResponse<PostReviewReportResponse>> postReviewReport(
+            @PathVariable Long reviewId,
+            @Valid @RequestBody PostReviewReportRequest request
+            ){
+        PostReviewReportResponse response = reviewReportService.postReviewReport(reviewId, request);
+        return ResponseEntity.ok(BaseResponse.onSuccess(SuccessStatus._OK, response));
+    }
+
+    //TODO 리뷰 삭제하기
+}

--- a/src/main/java/umc/catchy/domain/reviewReport/api/ReviewReportController.java
+++ b/src/main/java/umc/catchy/domain/reviewReport/api/ReviewReportController.java
@@ -4,11 +4,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import umc.catchy.domain.reviewReport.dto.request.PostReviewReportRequest;
+import umc.catchy.domain.reviewReport.dto.response.DeleteReviewResponse;
 import umc.catchy.domain.reviewReport.dto.response.PostReviewReportResponse;
 import umc.catchy.domain.reviewReport.service.ReviewReportService;
 import umc.catchy.global.common.response.BaseResponse;
@@ -31,4 +29,13 @@ public class ReviewReportController {
     }
 
     //TODO 리뷰 삭제하기
+    @Operation(summary = "리뷰 삭제 API", description = "코스리뷰, 장소리뷰 통합 리뷰 삭제 API입니다.")
+    @DeleteMapping("/mypage/reviews/{reviewId}")
+    public ResponseEntity<BaseResponse<DeleteReviewResponse>> deleteReview(
+            @PathVariable Long reviewId,
+            @RequestParam String reviewType
+    ){
+        DeleteReviewResponse response = reviewReportService.deleteReview(reviewId, reviewType);
+        return ResponseEntity.ok(BaseResponse.onSuccess(SuccessStatus._OK, response));
+    }
 }

--- a/src/main/java/umc/catchy/domain/reviewReport/converter/ReviewReportConverter.java
+++ b/src/main/java/umc/catchy/domain/reviewReport/converter/ReviewReportConverter.java
@@ -1,0 +1,35 @@
+package umc.catchy.domain.reviewReport.converter;
+
+import umc.catchy.domain.courseReview.domain.CourseReview;
+import umc.catchy.domain.placeReview.domain.PlaceReview;
+import umc.catchy.domain.reviewReport.domain.ReviewReport;
+import umc.catchy.domain.reviewReport.domain.ReviewType;
+import umc.catchy.domain.reviewReport.dto.request.PostReviewReportRequest;
+import umc.catchy.domain.reviewReport.dto.response.PostReviewReportResponse;
+
+public class ReviewReportConverter {
+
+    public static PostReviewReportResponse toPostReviewReportResponse(ReviewReport reviewReport) {
+        return PostReviewReportResponse.builder()
+                .reportId(reviewReport.getId())
+                .reviewType(reviewReport.getReviewType())
+                .message("해당 리뷰가 성공적으로 신고되었습니다.")
+                .build();
+    }
+
+    public static ReviewReport toCourseReviewReport(PostReviewReportRequest request, CourseReview courseReview) {
+        return ReviewReport.builder()
+                .reviewType(ReviewType.valueOf(request.getReviewType()))
+                .reason(request.getReason())
+                .courseReview(courseReview)
+                .build();
+    }
+
+    public static ReviewReport toPlaceReviewReport(PostReviewReportRequest request, PlaceReview placeReview){
+        return ReviewReport.builder()
+                .reviewType(ReviewType.valueOf(request.getReviewType()))
+                .reason(request.getReason())
+                .placeReview(placeReview)
+                .build();
+    }
+}

--- a/src/main/java/umc/catchy/domain/reviewReport/converter/ReviewReportConverter.java
+++ b/src/main/java/umc/catchy/domain/reviewReport/converter/ReviewReportConverter.java
@@ -5,9 +5,18 @@ import umc.catchy.domain.placeReview.domain.PlaceReview;
 import umc.catchy.domain.reviewReport.domain.ReviewReport;
 import umc.catchy.domain.reviewReport.domain.ReviewType;
 import umc.catchy.domain.reviewReport.dto.request.PostReviewReportRequest;
+import umc.catchy.domain.reviewReport.dto.response.DeleteReviewResponse;
 import umc.catchy.domain.reviewReport.dto.response.PostReviewReportResponse;
 
 public class ReviewReportConverter {
+
+    public static DeleteReviewResponse toDeleteReviewResponse(Long reviewId, ReviewType reviewType){
+        return DeleteReviewResponse.builder()
+                .reviewId(reviewId)
+                .reviewType(reviewType)
+                .message("해당 리뷰가 성공적으로 삭제되었습니다.")
+                .build();
+    }
 
     public static PostReviewReportResponse toPostReviewReportResponse(ReviewReport reviewReport) {
         return PostReviewReportResponse.builder()

--- a/src/main/java/umc/catchy/domain/reviewReport/dao/ReviewReportRepository.java
+++ b/src/main/java/umc/catchy/domain/reviewReport/dao/ReviewReportRepository.java
@@ -2,8 +2,12 @@ package umc.catchy.domain.reviewReport.dao;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import umc.catchy.domain.courseReview.domain.CourseReview;
+import umc.catchy.domain.placeReview.domain.PlaceReview;
 import umc.catchy.domain.reviewReport.domain.ReviewReport;
 
 @Repository
 public interface ReviewReportRepository extends JpaRepository<ReviewReport, Long> {
+    void deleteAllByPlaceReview(PlaceReview placeReview);
+    void deleteAllByCourseReview(CourseReview courseReview);
 }

--- a/src/main/java/umc/catchy/domain/reviewReport/dao/ReviewReportRepository.java
+++ b/src/main/java/umc/catchy/domain/reviewReport/dao/ReviewReportRepository.java
@@ -1,0 +1,9 @@
+package umc.catchy.domain.reviewReport.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import umc.catchy.domain.reviewReport.domain.ReviewReport;
+
+@Repository
+public interface ReviewReportRepository extends JpaRepository<ReviewReport, Long> {
+}

--- a/src/main/java/umc/catchy/domain/reviewReport/domain/ReviewReport.java
+++ b/src/main/java/umc/catchy/domain/reviewReport/domain/ReviewReport.java
@@ -1,0 +1,33 @@
+package umc.catchy.domain.reviewReport.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.catchy.domain.common.BaseTimeEntity;
+import umc.catchy.domain.courseReview.domain.CourseReview;
+import umc.catchy.domain.placeReview.domain.PlaceReview;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReviewReport extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_report_id")
+    private Long id;
+
+    private String reason;
+
+    @Enumerated(EnumType.STRING)
+    private ReviewType reviewType;
+
+    //리뷰 타입에 맞게 둘 중 하나만 값을 가지도록 함.
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_review_id", nullable = true)
+    private CourseReview courseReview;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_review_id", nullable = true)
+    private PlaceReview placeReview;
+}

--- a/src/main/java/umc/catchy/domain/reviewReport/domain/ReviewType.java
+++ b/src/main/java/umc/catchy/domain/reviewReport/domain/ReviewType.java
@@ -1,0 +1,13 @@
+package umc.catchy.domain.reviewReport.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ReviewType {
+    COURSE("COURSE"),
+    PLACE("PLACE");
+
+    private final String value;
+}

--- a/src/main/java/umc/catchy/domain/reviewReport/dto/request/PostReviewReportRequest.java
+++ b/src/main/java/umc/catchy/domain/reviewReport/dto/request/PostReviewReportRequest.java
@@ -1,0 +1,16 @@
+package umc.catchy.domain.reviewReport.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PostReviewReportRequest {
+    @NotBlank
+    @Pattern(regexp = "COURSE|PLACE", message = "리뷰 타입은 COURSE 또는 PLACE입니다.")
+    private String reviewType;
+    @NotBlank(message = "신고 이유를 적어주세요.")
+    private String reason;
+}

--- a/src/main/java/umc/catchy/domain/reviewReport/dto/response/DeleteReviewResponse.java
+++ b/src/main/java/umc/catchy/domain/reviewReport/dto/response/DeleteReviewResponse.java
@@ -1,0 +1,17 @@
+package umc.catchy.domain.reviewReport.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.catchy.domain.reviewReport.domain.ReviewType;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class DeleteReviewResponse {
+    Long reviewId;
+    ReviewType reviewType;
+    String message;
+}

--- a/src/main/java/umc/catchy/domain/reviewReport/dto/response/PostReviewReportResponse.java
+++ b/src/main/java/umc/catchy/domain/reviewReport/dto/response/PostReviewReportResponse.java
@@ -1,0 +1,17 @@
+package umc.catchy.domain.reviewReport.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.catchy.domain.reviewReport.domain.ReviewType;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostReviewReportResponse {
+    Long reportId;
+    ReviewType reviewType;
+    String message;
+}

--- a/src/main/java/umc/catchy/domain/reviewReport/service/ReviewReportService.java
+++ b/src/main/java/umc/catchy/domain/reviewReport/service/ReviewReportService.java
@@ -1,0 +1,51 @@
+package umc.catchy.domain.reviewReport.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.catchy.domain.courseReview.dao.CourseReviewRepository;
+import umc.catchy.domain.courseReview.domain.CourseReview;
+import umc.catchy.domain.placeReview.dao.PlaceReviewRepository;
+import umc.catchy.domain.placeReview.domain.PlaceReview;
+import umc.catchy.domain.reviewReport.converter.ReviewReportConverter;
+import umc.catchy.domain.reviewReport.dao.ReviewReportRepository;
+import umc.catchy.domain.reviewReport.domain.ReviewReport;
+import umc.catchy.domain.reviewReport.dto.request.PostReviewReportRequest;
+import umc.catchy.domain.reviewReport.dto.response.PostReviewReportResponse;
+import umc.catchy.global.common.response.status.ErrorStatus;
+import umc.catchy.global.error.exception.GeneralException;
+
+import java.util.Objects;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReviewReportService {
+
+    private final ReviewReportRepository reviewReportRepository;
+    private final CourseReviewRepository courseReviewRepository;
+    private final PlaceReviewRepository placeReviewRepository;
+
+    //리뷰 신고하기
+    //TODO 해당 리뷰의 state 변경
+    public PostReviewReportResponse postReviewReport(Long reviewId, PostReviewReportRequest request) {
+        if(Objects.equals(request.getReviewType(), "PLACE")){
+            PlaceReview placeReview = placeReviewRepository.findById(reviewId)
+                    .orElseThrow(()-> new GeneralException(ErrorStatus.PLACE_REVIEW_NOT_FOUND));
+
+            ReviewReport newReport = ReviewReportConverter.toPlaceReviewReport(request, placeReview);
+            reviewReportRepository.save(newReport);
+            return ReviewReportConverter.toPostReviewReportResponse(newReport);
+        }
+        else if(Objects.equals(request.getReviewType(), "COURSE")){
+            CourseReview courseReview = courseReviewRepository.findById(reviewId)
+                    .orElseThrow(()-> new GeneralException(ErrorStatus.COURSE_REVIEW_NOT_FOUND));
+
+            ReviewReport newReport = ReviewReportConverter.toCourseReviewReport(request, courseReview);
+            reviewReportRepository.save(newReport);
+            return ReviewReportConverter.toPostReviewReportResponse(newReport);
+        }
+        else throw new GeneralException(ErrorStatus._BAD_REQUEST);
+    }
+}

--- a/src/main/java/umc/catchy/domain/reviewReport/service/ReviewReportService.java
+++ b/src/main/java/umc/catchy/domain/reviewReport/service/ReviewReportService.java
@@ -88,7 +88,6 @@ public class ReviewReportService {
     }
 
     //리뷰 삭제하기
-    //TODO : REVIEW_REPORT 삭제
     public DeleteReviewResponse deleteReview(Long reviewId, String reviewType){
         Long memberId = SecurityUtil.getCurrentMemberId();
         Member member = memberRepository.findById(memberId)
@@ -104,6 +103,7 @@ public class ReviewReportService {
                 throw new GeneralException(ErrorStatus.REVIEW_DELETE_INVALID);
             }
             DeletePlaceReviewImages(placeReview);
+            reviewReportRepository.deleteAllByPlaceReview(placeReview);
             placeReviewRepository.delete(placeReview);
         }
         else {
@@ -114,6 +114,7 @@ public class ReviewReportService {
                 throw new GeneralException(ErrorStatus.REVIEW_DELETE_INVALID);
             }
             DeleteCourseReviewImages(courseReview);
+            reviewReportRepository.deleteAllByCourseReview(courseReview);
             courseReviewRepository.delete(courseReview);
         }
         return ReviewReportConverter.toDeleteReviewResponse(reviewId, type);

--- a/src/main/java/umc/catchy/domain/reviewReport/service/ReviewReportService.java
+++ b/src/main/java/umc/catchy/domain/reviewReport/service/ReviewReportService.java
@@ -1,21 +1,32 @@
 package umc.catchy.domain.reviewReport.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.catchy.domain.courseReview.dao.CourseReviewRepository;
 import umc.catchy.domain.courseReview.domain.CourseReview;
+import umc.catchy.domain.courseReviewImage.dao.CourseReviewImageRepository;
+import umc.catchy.domain.courseReviewImage.domain.CourseReviewImage;
+import umc.catchy.domain.member.dao.MemberRepository;
+import umc.catchy.domain.member.domain.Member;
 import umc.catchy.domain.placeReview.dao.PlaceReviewRepository;
 import umc.catchy.domain.placeReview.domain.PlaceReview;
+import umc.catchy.domain.placeReviewImage.dao.PlaceReviewImageRepository;
+import umc.catchy.domain.placeReviewImage.domain.PlaceReviewImage;
 import umc.catchy.domain.reviewReport.converter.ReviewReportConverter;
 import umc.catchy.domain.reviewReport.dao.ReviewReportRepository;
 import umc.catchy.domain.reviewReport.domain.ReviewReport;
+import umc.catchy.domain.reviewReport.domain.ReviewType;
 import umc.catchy.domain.reviewReport.dto.request.PostReviewReportRequest;
+import umc.catchy.domain.reviewReport.dto.response.DeleteReviewResponse;
 import umc.catchy.domain.reviewReport.dto.response.PostReviewReportResponse;
 import umc.catchy.global.common.response.status.ErrorStatus;
 import umc.catchy.global.error.exception.GeneralException;
+import umc.catchy.global.util.SecurityUtil;
+import umc.catchy.infra.aws.s3.AmazonS3Manager;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 @Service
@@ -25,10 +36,23 @@ public class ReviewReportService {
 
     private final ReviewReportRepository reviewReportRepository;
     private final CourseReviewRepository courseReviewRepository;
+    private final CourseReviewImageRepository courseReviewImageRepository;
     private final PlaceReviewRepository placeReviewRepository;
+    private final PlaceReviewImageRepository placeReviewImageRepository;
+    private final MemberRepository memberRepository;
+    private final AmazonS3Manager s3Manager;
+
+    //리뷰 타입 ENUM 변환
+    private ReviewType parseReviewType(String reviewType) {
+        return Arrays.stream(ReviewType.values())
+                .filter(t -> t.name().equalsIgnoreCase(reviewType))
+                .findFirst()
+                .orElseThrow(()-> new GeneralException(ErrorStatus._BAD_REQUEST, "리뷰 타입은 COURSE 또는 PLACE 입니다."));
+    }
 
     //리뷰 신고하기
     //TODO 해당 리뷰의 state 변경
+    //TODO report 중복 판단
     public PostReviewReportResponse postReviewReport(Long reviewId, PostReviewReportRequest request) {
         if(Objects.equals(request.getReviewType(), "PLACE")){
             PlaceReview placeReview = placeReviewRepository.findById(reviewId)
@@ -47,5 +71,51 @@ public class ReviewReportService {
             return ReviewReportConverter.toPostReviewReportResponse(newReport);
         }
         else throw new GeneralException(ErrorStatus._BAD_REQUEST);
+    }
+
+    //리뷰 이미지 삭제 : PLACE
+    private void DeletePlaceReviewImages(PlaceReview placeReview){
+        List<PlaceReviewImage> images = placeReviewImageRepository.findAllByPlaceReview(placeReview);
+        images.forEach(image -> s3Manager.deleteImage(image.getImageUrl()));
+        placeReviewImageRepository.deleteAllByPlaceReview(placeReview);
+    }
+
+    //리뷰 이미지 삭제 : COURSE
+    private void DeleteCourseReviewImages(CourseReview courseReview){
+        List<CourseReviewImage> images = courseReviewImageRepository.findAllByCourseReview(courseReview);
+        images.forEach(image -> s3Manager.deleteImage(image.getImageUrl()));
+        courseReviewImageRepository.deleteAllByCourseReview(courseReview);
+    }
+
+    //리뷰 삭제하기
+    //TODO : REVIEW_REPORT 삭제
+    public DeleteReviewResponse deleteReview(Long reviewId, String reviewType){
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        ReviewType type = parseReviewType(reviewType);
+
+        if(type==ReviewType.PLACE){
+            PlaceReview placeReview = placeReviewRepository.findById(reviewId)
+                    .orElseThrow(()-> new GeneralException(ErrorStatus.PLACE_REVIEW_NOT_FOUND));
+
+            if(!placeReview.getMember().equals(member)){
+                throw new GeneralException(ErrorStatus.REVIEW_DELETE_INVALID);
+            }
+            DeletePlaceReviewImages(placeReview);
+            placeReviewRepository.delete(placeReview);
+        }
+        else {
+            CourseReview courseReview = courseReviewRepository.findById(reviewId)
+                    .orElseThrow(()-> new GeneralException(ErrorStatus.COURSE_REVIEW_NOT_FOUND));
+
+            if(!courseReview.getMember().equals(member)){
+                throw new GeneralException(ErrorStatus.REVIEW_DELETE_INVALID);
+            }
+            DeleteCourseReviewImages(courseReview);
+            courseReviewRepository.delete(courseReview);
+        }
+        return ReviewReportConverter.toDeleteReviewResponse(reviewId, type);
     }
 }

--- a/src/main/java/umc/catchy/global/common/response/status/ErrorStatus.java
+++ b/src/main/java/umc/catchy/global/common/response/status/ErrorStatus.java
@@ -32,6 +32,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //장소 관련 에러
     PLACE_REVIEW_INVALID_MEMBER(HttpStatus.BAD_REQUEST, "PLACE_REVIEW_MEMBER400", "해당 멤버는 장소 리뷰를 달 수 있는 권한이 없습니다."),
+    PLACE_REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE_REVIEW404","해당 장소리뷰를 찾을 수 없습니다."),
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE404", "해당 장소를 찾을 수 없습니다."),
     SEARCH_PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "SEARCH_PLACE404", "찾는 장소가 없습니다."),
 
@@ -41,6 +42,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //코스 관련 에러
     COURSE_REVIEW_INVALID_MEMBER(HttpStatus.BAD_REQUEST, "COURSE_REVIEW_MEMBER400", "해당 멤버는 코스 리뷰를 달 수 있는 권한이 없습니다."),
+    COURSE_REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND,"COURSE_REVIEW404", "해당 코스리뷰를 찾을 수 없습니다."),
     COURSE_INVALID_MEMBER(HttpStatus.BAD_REQUEST, "COURSE_MEMBER400", "해당 멤버는 코스를 수정하거나 삭제할 수 있는 권한이 없습니다."),
     COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "COURSE404", "해당 코스를 찾을 수 없습니다."),
     INVALID_COURSE_TYPE(HttpStatus.BAD_REQUEST, "COURSE_TYPE400", "코스타입 입력이 잘못되었습니다."),

--- a/src/main/java/umc/catchy/global/common/response/status/ErrorStatus.java
+++ b/src/main/java/umc/catchy/global/common/response/status/ErrorStatus.java
@@ -74,6 +74,9 @@ public enum ErrorStatus implements BaseErrorCode {
     JSON_PARSING_ERROR(HttpStatus.NOT_FOUND, "GPT404", "json 파싱 에러"),
     IMAGE_GENERATION_ERROR(HttpStatus.BAD_REQUEST, "GPT402", "이미지 생성에 실패하였습니다."),
     GPT_API_CALL_FAILED(HttpStatus.NOT_FOUND, "GPT404", "GPT 호출에 실패했습니다."),
+
+    //리뷰 관련 에러
+    REVIEW_DELETE_INVALID(HttpStatus.BAD_REQUEST, "REVIEW400", "해당 멤버는 리뷰 삭제 권한이 없습니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📌 Issue Number

- close #139 

## 🪐 작업 내용

- 리뷰 신고 및 삭제 기능 구현

## ✅ PR 상세 내용

- ReviewReport 엔티티 생성
- 리뷰 신고 기능 구현
- 리뷰 삭제 기능 구현 : 삭제 이전에 이미지와 reviewReport 정보도 함께 삭제

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/5a105153-e498-4203-802f-31a72f9aede7)
![image](https://github.com/user-attachments/assets/6a4ef575-29e2-4a28-a118-290e9dd62aa0)


## ❌ 애로 사항

- 리뷰 타입에 따라 다른 로직을 수행하는데, 비슷한 코드가 많아서 Review라는 상위 엔티티를 만들고 courseReview와 placeReview에 대한 로직을 제네릭하게 만들면 코드를 더 깔끔하게 만들 수 있을 것 같음.
- 신고된 리뷰에 대해 상태가 변경되고 조회가 불가능하게 조회 코드 및 엔티티를 수정할 필요가 있음.
- 리뷰 신고 중복 검사 로직 추가 필요

## 📚 Reference
