### PR TITLE
[fix] 회원 탈퇴 로직 수정

### DIFF
--- a/src/main/java/umc/catchy/domain/mapping/memberActivetime/dao/MemberActiveTimeRepository.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberActivetime/dao/MemberActiveTimeRepository.java
@@ -8,6 +8,7 @@ import umc.catchy.domain.mapping.memberActivetime.domain.MemberActiveTime;
 
 import java.time.DayOfWeek;
 import java.util.List;
+import umc.catchy.domain.member.domain.Member;
 
 @Repository
 public interface MemberActiveTimeRepository extends JpaRepository<MemberActiveTime, Long> {
@@ -16,4 +17,5 @@ public interface MemberActiveTimeRepository extends JpaRepository<MemberActiveTi
     @Query("SELECT mat FROM MemberActiveTime mat JOIN FETCH mat.activeTime at " +
             "WHERE mat.member.id = :memberId AND at.dayOfWeek = :today")
     List<MemberActiveTime> findActiveTimeByMemberIdAndDayOfWeek(@Param("memberId") Long memberId, @Param("today") DayOfWeek today);
+    Integer deleteAllByMember(Member member);
 }

--- a/src/main/java/umc/catchy/domain/mapping/memberCategory/dao/MemberCategoryRepository.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCategory/dao/MemberCategoryRepository.java
@@ -4,7 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import umc.catchy.domain.mapping.memberCategory.domain.MemberCategory;
 
 import java.util.List;
+import umc.catchy.domain.member.domain.Member;
 
 public interface MemberCategoryRepository extends JpaRepository<MemberCategory, Long> {
     List<MemberCategory> findByMemberId(Long memberId);
+    Integer deleteAllByMember(Member member);
 }

--- a/src/main/java/umc/catchy/domain/mapping/memberCategoryVote/dao/MemberCategoryVoteRepository.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCategoryVote/dao/MemberCategoryVoteRepository.java
@@ -31,4 +31,5 @@ public interface MemberCategoryVoteRepository extends JpaRepository<MemberCatego
             "WHERE mcv.categoryVote.id = :categoryVoteId " +
             "AND mcv.categoryVote.vote.group.id = :groupId")
     int countByCategoryVoteIdAndGroupId(@Param("categoryVoteId") Long categoryVoteId, @Param("groupId") Long groupId);
+    Integer deleteAllByMember(Member member);
 }

--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/dao/MemberCourseRepository.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/dao/MemberCourseRepository.java
@@ -14,4 +14,5 @@ public interface MemberCourseRepository extends JpaRepository<MemberCourse, Long
     Optional<MemberCourse> findByCourseAndMember(Course course, Member member);
     List<MemberCourse> findAllByMember(Member member);
     Optional<MemberCourse> findByCourseIdAndMemberId(Long courseId, Long memberId);
+    Integer deleteAllByMember(Member member);
 }

--- a/src/main/java/umc/catchy/domain/mapping/memberGroup/dao/MemberGroupRepository.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberGroup/dao/MemberGroupRepository.java
@@ -21,4 +21,5 @@ public interface MemberGroupRepository extends JpaRepository<MemberGroup, Long> 
     int countByGroupId(Long groupId);
     @Query("SELECT mg.member FROM MemberGroup mg WHERE mg.group.id = :groupId")
     List<Member> findMembersByGroupId(@Param("groupId") Long groupId);
+    Integer deleteAllByMember(Member member);
 }

--- a/src/main/java/umc/catchy/domain/mapping/memberLocation/dao/MemberLocationRepository.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberLocation/dao/MemberLocationRepository.java
@@ -5,8 +5,10 @@ import org.springframework.stereotype.Repository;
 import umc.catchy.domain.mapping.memberLocation.domain.MemberLocation;
 
 import java.util.List;
+import umc.catchy.domain.member.domain.Member;
 
 @Repository
 public interface MemberLocationRepository extends JpaRepository<MemberLocation, Long> {
     List<MemberLocation> findAllByMemberId(Long memberId);
+    Integer deleteAllByMember(Member member);
 }

--- a/src/main/java/umc/catchy/domain/mapping/memberPlaceVote/dao/MemberPlaceVoteRepository.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberPlaceVote/dao/MemberPlaceVoteRepository.java
@@ -19,4 +19,6 @@ public interface MemberPlaceVoteRepository extends JpaRepository<MemberPlaceVote
     MemberPlaceVote findByMemberIdAndPlaceIdAndVoteId(Long memberId, Long placeId, Long voteId);
     @Query("SELECT COUNT(mpv) FROM MemberPlaceVote mpv WHERE mpv.place.id = :placeId")
     int countByPlaceId(@Param("placeId") Long placeId);
+
+    Integer deleteAllByMember(Member member);
 }

--- a/src/main/java/umc/catchy/domain/mapping/memberStyle/dao/MemberStyleRepository.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberStyle/dao/MemberStyleRepository.java
@@ -5,8 +5,10 @@ import org.springframework.stereotype.Repository;
 import umc.catchy.domain.mapping.memberStyle.domain.MemberStyle;
 
 import java.util.List;
+import umc.catchy.domain.member.domain.Member;
 
 @Repository
 public interface MemberStyleRepository extends JpaRepository<MemberStyle, Long> {
     List<MemberStyle> findByMemberId(Long memberId);
+    Integer deleteAllByMember(Member member);
 }

--- a/src/main/java/umc/catchy/domain/member/api/MemberController.java
+++ b/src/main/java/umc/catchy/domain/member/api/MemberController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -109,9 +110,9 @@ public class MemberController {
     }
 
     @DeleteMapping("/withdraw")
-    @Operation(summary = "회원 탈퇴 API ", description = "현재 로그인된 사용자 탈퇴")
-    public BaseResponse<Void> withdrawMember() {
-        memberService.withdraw();
+    @Operation(summary = "회원 탈퇴 API ", description = "현재 로그인된 사용자 탈퇴 / 애플 탈퇴 시 인가 코드를 입력")
+    public BaseResponse<Void> withdrawMember(@RequestParam(required = false) String authorizationCode) {
+        memberService.withdraw(authorizationCode);
 
         return BaseResponse.onSuccess(SuccessStatus._OK, null);
     }


### PR DESCRIPTION
## 📌 Issue Number

- close #152 

## 🪐 작업 내용

- 회원 탈퇴 로직 수정

## ✅ PR 상세 내용

- 회원 탈퇴 시 관련 연관 테이블 삭제
- 애플 탈퇴 시 인가 코드를 받아서 탈퇴 (인가코드에 유효기간이 있음)
  - 애플 로그인 -> 인가 코드 서버로 전달 -> 회원 탈퇴

