### PR TITLE
[fix] 홈 화면의 AI 코스 - "내 코스 조회"에서 제외

### DIFF
--- a/src/main/java/umc/catchy/domain/course/api/CourseController.java
+++ b/src/main/java/umc/catchy/domain/course/api/CourseController.java
@@ -122,7 +122,7 @@ public class CourseController {
     @Operation(summary = "코스 생성(AI) API", description = "AI가 생성하는 코스")
     @PostMapping("/generate-ai")
     public CompletableFuture<ResponseEntity<BaseResponse<GptCourseInfoResponse>>> generateCourseWithAI() {
-        return courseService.generateCourseAutomatically()
+        return courseService.generateCourseAutomatically(false)
                 .thenApply(response -> ResponseEntity.ok(BaseResponse.onSuccess(SuccessStatus._OK, response)));
     }
 

--- a/src/main/java/umc/catchy/domain/course/service/CourseService.java
+++ b/src/main/java/umc/catchy/domain/course/service/CourseService.java
@@ -362,6 +362,11 @@ public class CourseService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
+        if (!isForHome) {
+            member.increaseGptCount();
+            memberRepository.save(member);
+        }
+
         List<MemberLocation> memberLocations = memberLocationRepository.findAllByMemberId(memberId);
         List<String> preferredCategories = getPreferredCategories(memberId);
         List<String> userStyles = getUserStyles(memberId);
@@ -473,7 +478,7 @@ public class CourseService {
         savedCourse.setRating(courseRating);
         courseRepository.saveAndFlush(savedCourse);
 
-        // 🔥 홈 추천 AI 코스가 아니라면 MemberCourse에 저장
+        // 홈 추천 AI 코스가 아니라면 MemberCourse에 저장
         if (!isForHome) {
             MemberCourse memberCourse = MemberCourse.builder()
                     .course(savedCourse)

--- a/src/main/java/umc/catchy/domain/member/domain/Member.java
+++ b/src/main/java/umc/catchy/domain/member/domain/Member.java
@@ -46,7 +46,15 @@ public class Member extends BaseTimeEntity {
     @Setter
     private String authorizationCode;
 
-    private Integer gpt_count;
+    @Column(nullable = false)
+    private Integer gpt_count = 0;
+
+    public void increaseGptCount() {
+        if (this.gpt_count == null) {
+            this.gpt_count = 0;
+        }
+        this.gpt_count += 1;
+    }
 
     public static Member createMember(
             String providerId,


### PR DESCRIPTION
## 📌 Issue Number

- close #166 

## 🪐 작업 내용

- 홈 화면에서 AI가 생성한 코스가 "내 코스 조회"에서 제외되도록 수정  
- AI 추천 코스 요청 시 `gpt_count` 증가 로직 추가  
- 이미지 생성 프롬프트 개선 (코스 설명에 맞게 최적화)  

## ✅ PR 상세 내용

 - 홈 화면에서 제공하는 AI 추천 코스를 `MemberCourse` 테이블에 저장하지 않도록 변경
   - "내 코스 조회" API에서 홈 화면의 AI 생성 코스가 조회되지 않도록 함
- AI 추천 코스를 요청할 때 `gpt_count`가 증가하도록 수정 
- 이미지 생성 프롬프트 최적화

## 📸 스크린샷(선택)


## ❌ 애로 사항

- 이미지 생성이 더 디테일해지면서 소요 시간이 다소 증가

## 📚 Reference

