### PR TITLE
[fix] AI 추천 코스 응답 수정

### DIFF
--- a/src/main/java/umc/catchy/CatchyApplication.java
+++ b/src/main/java/umc/catchy/CatchyApplication.java
@@ -4,9 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableJpaAuditing
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
+@EnableAsync
 public class CatchyApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/umc/catchy/domain/course/dto/response/GptCourseInfoResponse.java
+++ b/src/main/java/umc/catchy/domain/course/dto/response/GptCourseInfoResponse.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import umc.catchy.domain.category.domain.BigCategory;
 
 import java.util.List;
 
@@ -23,11 +24,27 @@ public class GptCourseInfoResponse {
     @Getter
     @Setter
     @NoArgsConstructor
-    @AllArgsConstructor
     public static class GptPlaceInfoResponse {
         private Long placeId;
-        private String name;
+        private String placeName;
+        private String placeImage;
+        private String category;
         private String roadAddress;
-        private String recommendVisitTime; // "HH:mm~HH:mm" 형식
+        private String activeTime;
+        private double rating;
+        private int reviewCount;
+
+        // QueryDSL을 위한 생성자
+        public GptPlaceInfoResponse(Long placeId, String placeName, String placeImage, String categoryKey,
+                                    String roadAddress, String activeTime, double rating, int reviewCount) {
+            this.placeId = placeId;
+            this.placeName = placeName;
+            this.placeImage = placeImage;
+            this.category = BigCategory.valueOf(categoryKey).getValue();
+            this.roadAddress = roadAddress;
+            this.activeTime = activeTime;
+            this.rating = rating;
+            this.reviewCount = reviewCount;
+        }
     }
 }

--- a/src/main/java/umc/catchy/domain/course/service/CourseService.java
+++ b/src/main/java/umc/catchy/domain/course/service/CourseService.java
@@ -299,40 +299,20 @@ public class CourseService {
         List<Long> placeIds = request.getPlaceIds();
 
         // 평점 계산
-        // 평점 계산 및 디버깅
         Double averageRating = placeIds.stream()
-                .map(placeId -> {
-                    Place place = placeRepository.findById(placeId)
-                            .orElseThrow(() -> new GeneralException(ErrorStatus.PLACE_NOT_FOUND));
-
-                    Double rating = place.getRating();
-                    if (rating == null) {
-                        System.out.println("DEBUG: Place ID " + placeId + " has NULL rating.");
-                        return 0.0;  // Null인 경우 0.0으로 처리
-                    } else {
-                        System.out.println("DEBUG: Place ID " + placeId + " has rating: " + rating);
-                        return rating;
-                    }
-                })
+                .map(placeId -> placeRepository.findById(placeId)
+                        .orElseThrow(() -> new GeneralException(ErrorStatus.PLACE_NOT_FOUND))
+                        .getRating())
                 .mapToDouble(Double::doubleValue)
                 .average()
                 .orElse(0.0);
 
-// 평균 평점 출력
-        System.out.println("DEBUG: Calculated average rating before rounding: " + averageRating);
-
-// 소수점 첫째 자리에서 반올림하여 저장
         course.setRating(Math.round(averageRating * 10) / 10.0);
-        System.out.println("DEBUG: Rounded average rating set to course: " + course.getRating());
 
-// 코스 순서대로 장소 저장
         IntStream.range(0, placeIds.size()).forEach(index -> {
             Long placeId = placeIds.get(index);
             Place place = placeRepository.findById(placeId)
                     .orElseThrow(() -> new GeneralException(ErrorStatus.PLACE_NOT_FOUND));
-
-            // 디버깅: 코스 순서 확인
-            System.out.println("DEBUG: Adding place with ID " + placeId + " to course with order " + (index + 1));
 
             // List의 Index를 기반으로 코스 순서 결정
             PlaceCourse newPlaceCourse = PlaceCourse.builder()
@@ -343,7 +323,6 @@ public class CourseService {
 
             placeCourseRepository.save(newPlaceCourse);
         });
-
 
         // MemberCourse 생성
         MemberCourse memberCourse = MemberCourse.builder()

--- a/src/main/java/umc/catchy/domain/place/dao/PlaceCustomRepository.java
+++ b/src/main/java/umc/catchy/domain/place/dao/PlaceCustomRepository.java
@@ -2,6 +2,7 @@ package umc.catchy.domain.place.dao;
 
 import java.util.Map;
 import org.springframework.data.domain.Slice;
+import umc.catchy.domain.course.dto.response.GptCourseInfoResponse;
 import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoPreview;
 import umc.catchy.domain.place.domain.Place;
 
@@ -11,4 +12,5 @@ public interface PlaceCustomRepository {
     List<Place> findPlacesByDynamicFilters(List<Long> categoryIds, List<String> upperRegions, List<String> lowerRegions);
     List<Place> findRecommendedPlaces(List<Long> categoryIds, List<String> upperRegions, List<String> lowerRegions, Long memberId, int maxPlaces);
     Slice<PlaceInfoPreview> recommendPlacesByActivityData(Long memberId, Double latitude, Double longitude, List<Long> categoryIds, Map<Long, Integer> hourMap, int pageSize, int page);
+    List<GptCourseInfoResponse.GptPlaceInfoResponse> findPlacesWithCategoryAndReviewCount(List<Long> placeIds);
 }


### PR DESCRIPTION
## 📌 Issue Number

- close #176 

## 🪐 작업 내용

- AI 추천 코스 생성 응답 dto 수정

## ✅ PR 상세 내용

- QueryDSL을 활용해 장소, 카테고리, 리뷰 개수를 한 번에 조회하는 메서드 사
- 응답(GptCourseInfoResponse)에 포함되는 장소 정보에 카테고리, 이미지, 평점, 리뷰 개수를 포함하도록 수정

## 📸 스크린샷(선택)

- ![image](https://github.com/user-attachments/assets/cc7e0a0b-2e57-4394-80e0-b767eb89fb8a)


## ❌ 애로 사항

- 

## 📚 Reference

- 
