### PR TITLE
[fix] 카테고리 별 장소 확인 무한스크롤

### DIFF
--- a/src/main/java/umc/catchy/domain/place/dao/PlaceCustomRepository.java
+++ b/src/main/java/umc/catchy/domain/place/dao/PlaceCustomRepository.java
@@ -2,6 +2,7 @@ package umc.catchy.domain.place.dao;
 
 import java.util.Map;
 import org.springframework.data.domain.Slice;
+import umc.catchy.domain.category.domain.BigCategory;
 import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoPreview;
 import umc.catchy.domain.place.domain.Place;
 
@@ -11,4 +12,5 @@ public interface PlaceCustomRepository {
     List<Place> findPlacesByDynamicFilters(List<Long> categoryIds, List<String> upperRegions, List<String> lowerRegions);
     List<Place> findRecommendedPlaces(List<Long> categoryIds, List<String> upperRegions, List<String> lowerRegions, Long memberId, int maxPlaces);
     Slice<PlaceInfoPreview> recommendPlacesByActivityData(Long memberId, Double latitude, Double longitude, List<Long> categoryIds, Map<Long, Integer> hourMap, int pageSize, int page);
+    Slice<Place> getPlacesByCategoryWithPaging(BigCategory bigCategory, String groupLocation, String alternativeLocation, int pageSize, Long lastPlaceId);
 }

--- a/src/main/java/umc/catchy/domain/place/dao/PlaceRepositoryImpl.java
+++ b/src/main/java/umc/catchy/domain/place/dao/PlaceRepositoryImpl.java
@@ -276,30 +276,4 @@ public class PlaceRepositoryImpl implements PlaceCustomRepository {
 
         return new SliceImpl<>(places, PageRequest.of(0, pageSize), hasNext);
     }
-
-
-    private BooleanExpression lastPlacePagingCondition(Long lastPlaceId) {
-        if (lastPlaceId == null) {
-            return null;
-        }
-
-        // 서브쿼리로 lastPlaceId에 해당하는 voteCount와 placeName을 가져오기
-        Tuple lastPlaceInfo = queryFactory
-                .select(memberPlaceVote.count(), place.placeName)
-                .from(place)
-                .leftJoin(memberPlaceVote).on(memberPlaceVote.place.id.eq(place.id))
-                .where(place.id.eq(lastPlaceId))
-                .fetchOne();
-
-        Long lastVoteCount = lastPlaceInfo.get(memberPlaceVote.count());
-        String lastPlaceName = lastPlaceInfo.get(place.placeName);
-
-        // 복합 조건 적용: voteCount, placeName, placeId
-        return memberPlaceVote.count().lt(lastVoteCount)
-                .or(memberPlaceVote.count().eq(lastVoteCount)
-                        .and(place.placeName.gt(lastPlaceName)))
-                .or(memberPlaceVote.count().eq(lastVoteCount)
-                        .and(place.placeName.eq(lastPlaceName))
-                        .and(place.id.gt(lastPlaceId)));
-    }
 }

--- a/src/main/java/umc/catchy/domain/place/dao/PlaceRepositoryImpl.java
+++ b/src/main/java/umc/catchy/domain/place/dao/PlaceRepositoryImpl.java
@@ -1,10 +1,16 @@
 package umc.catchy.domain.place.dao;
 
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static java.util.Collections.list;
+import static umc.catchy.domain.category.domain.QCategory.category;
+import static umc.catchy.domain.mapping.memberPlaceVote.domain.QMemberPlaceVote.memberPlaceVote;
 import static umc.catchy.domain.mapping.placeLike.domain.QPlaceLike.placeLike;
 import static umc.catchy.domain.mapping.placeVisit.domain.QPlaceVisit.placeVisit;
+import static umc.catchy.domain.member.domain.QMember.member;
 import static umc.catchy.domain.place.domain.QPlace.place;
 import static umc.catchy.domain.placeReview.domain.QPlaceReview.placeReview;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -23,6 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+import umc.catchy.domain.category.domain.BigCategory;
 import umc.catchy.domain.course.util.LocationUtils;
 import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoPreview;
 import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoResponse;
@@ -33,6 +40,10 @@ import umc.catchy.domain.place.domain.QPlace;
 
 import java.util.List;
 import umc.catchy.domain.placeReview.domain.QPlaceReview;
+import umc.catchy.domain.vote.dto.response.PlaceResponse;
+import umc.catchy.domain.vote.dto.response.VotedMemberResponse;
+import umc.catchy.global.common.response.status.ErrorStatus;
+import umc.catchy.global.error.exception.GeneralException;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -212,5 +223,83 @@ public class PlaceRepositoryImpl implements PlaceCustomRepository {
                         .from(placeVisit)
                         .where(placeVisit.member.id.eq(memberId))
         );
+    }
+
+    public Slice<Place> getPlacesByCategoryWithPaging(BigCategory bigCategory, String groupLocation, String alternativeLocation, int pageSize, Long lastPlaceId) {
+        // 마지막 장소 정보를 가져와서 페이징 기준 설정
+        Tuple lastPlaceInfo = null;
+        if (lastPlaceId != null) {
+            lastPlaceInfo = queryFactory
+                    .select(place.id, memberPlaceVote.count(), place.placeName)
+                    .from(place)
+                    .leftJoin(memberPlaceVote).on(memberPlaceVote.place.id.eq(place.id))
+                    .where(place.id.eq(lastPlaceId))
+                    .groupBy(place.id, place.placeName)
+                    .fetchOne();
+        }
+
+        Long lastVoteCount = lastPlaceInfo != null ? lastPlaceInfo.get(memberPlaceVote.count()) : null;
+        String lastPlaceName = lastPlaceInfo != null ? lastPlaceInfo.get(place.placeName) : null;
+
+        List<Place> places = queryFactory
+                .selectFrom(place)
+                .leftJoin(memberPlaceVote).on(memberPlaceVote.place.id.eq(place.id))
+                .join(place.category, category)
+                .where(
+                        category.bigCategory.eq(bigCategory),
+                        place.roadAddress.like("%" + groupLocation + "%")
+                                .or(place.roadAddress.like("%" + alternativeLocation + "%"))
+                )
+                .groupBy(place.id)
+                .having(
+                        lastPlaceId == null ? null : (
+                                memberPlaceVote.count().lt(lastVoteCount)
+                                        .or(memberPlaceVote.count().eq(lastVoteCount)
+                                                .and(place.placeName.gt(lastPlaceName)))
+                                        .or(memberPlaceVote.count().eq(lastVoteCount)
+                                                .and(place.placeName.eq(lastPlaceName))
+                                                .and(place.id.gt(lastPlaceId)))
+                        )
+                )
+                .orderBy(
+                        memberPlaceVote.count().desc(),  // 투표 수 많은 순
+                        place.placeName.asc(),           // 이름순 정렬
+                        place.id.asc()                   // ID 정렬
+                )
+                .limit(pageSize + 1)
+                .fetch();
+
+        boolean hasNext = places.size() > pageSize;
+        if (hasNext) {
+            places.remove(pageSize);
+        }
+
+        return new SliceImpl<>(places, PageRequest.of(0, pageSize), hasNext);
+    }
+
+
+    private BooleanExpression lastPlacePagingCondition(Long lastPlaceId) {
+        if (lastPlaceId == null) {
+            return null;
+        }
+
+        // 서브쿼리로 lastPlaceId에 해당하는 voteCount와 placeName을 가져오기
+        Tuple lastPlaceInfo = queryFactory
+                .select(memberPlaceVote.count(), place.placeName)
+                .from(place)
+                .leftJoin(memberPlaceVote).on(memberPlaceVote.place.id.eq(place.id))
+                .where(place.id.eq(lastPlaceId))
+                .fetchOne();
+
+        Long lastVoteCount = lastPlaceInfo.get(memberPlaceVote.count());
+        String lastPlaceName = lastPlaceInfo.get(place.placeName);
+
+        // 복합 조건 적용: voteCount, placeName, placeId
+        return memberPlaceVote.count().lt(lastVoteCount)
+                .or(memberPlaceVote.count().eq(lastVoteCount)
+                        .and(place.placeName.gt(lastPlaceName)))
+                .or(memberPlaceVote.count().eq(lastVoteCount)
+                        .and(place.placeName.eq(lastPlaceName))
+                        .and(place.id.gt(lastPlaceId)));
     }
 }

--- a/src/main/java/umc/catchy/domain/vote/api/VoteController.java
+++ b/src/main/java/umc/catchy/domain/vote/api/VoteController.java
@@ -85,13 +85,16 @@ public class VoteController {
         return ResponseEntity.ok(BaseResponse.onSuccess(SuccessStatus._OK, response));
     }
 
-    @Operation(summary = "투표 완료 -카테고리 별 장소 확인", description = "카테고리 별 장소를 조회합니다.")
+    @Operation(summary = "투표 완료 - 카테고리 별 장소 확인", description = "카테고리 별 장소를 조회합니다.")
     @GetMapping("/{groupId}/categories/{category}/places")
     public ResponseEntity<BaseResponse<GroupPlaceResponse>> getPlacesByCategory(
             @PathVariable Long groupId,
             @Parameter(description = "카테고리 값", schema = @Schema(implementation = BigCategory.class))
-            @PathVariable BigCategory category) {
-        GroupPlaceResponse response = voteService.getPlacesByCategory(groupId, category.name());
+            @PathVariable BigCategory category,
+            @RequestParam(defaultValue = "10") int pageSize,
+            @RequestParam(required = false) Long lastPlaceId
+    ) {
+        GroupPlaceResponse response = voteService.getPlacesByCategory(groupId, category.name(), pageSize, lastPlaceId);
         return ResponseEntity.ok(BaseResponse.onSuccess(SuccessStatus._OK, response));
     }
 

--- a/src/main/java/umc/catchy/domain/vote/dto/response/GroupPlaceResponse.java
+++ b/src/main/java/umc/catchy/domain/vote/dto/response/GroupPlaceResponse.java
@@ -10,4 +10,5 @@ import java.util.List;
 public class GroupPlaceResponse {
     private String groupLocation;
     private List<PlaceResponse> places;
+    private Boolean isLast;
 }

--- a/src/main/java/umc/catchy/domain/vote/service/VoteService.java
+++ b/src/main/java/umc/catchy/domain/vote/service/VoteService.java
@@ -1,6 +1,7 @@
 package umc.catchy.domain.vote.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.catchy.domain.category.dao.CategoryRepository;
@@ -230,7 +231,7 @@ public class VoteService {
     }
 
     @Transactional(readOnly = true)
-    public GroupPlaceResponse getPlacesByCategory(Long groupId, String category) {
+    public GroupPlaceResponse getPlacesByCategory(Long groupId, String category, int pageSize, Long lastPlaceId) {
         Groups group = groupRepository.findById(groupId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.GROUP_NOT_FOUND));
         String groupLocation = group.getGroupLocation();
@@ -238,13 +239,16 @@ public class VoteService {
         String normalizedGroupLocation = LocationUtils.normalizeLocation(groupLocation);
         String normalizedAlternativeLocation = LocationUtils.normalizeLocation(normalizedGroupLocation);
 
-        List<Place> places = placeRepository.findByBigCategoryAndLocation(
+        // QueryDSL을 활용해 카테고리 필터링 + 투표 수 정렬 + 페이징 처리
+        Slice<Place> placesSlice = placeRepository.getPlacesByCategoryWithPaging(
                 BigCategory.valueOf(category),
                 normalizedGroupLocation,
-                normalizedAlternativeLocation
+                normalizedAlternativeLocation,
+                pageSize,
+                lastPlaceId
         );
 
-        List<PlaceResponse> placeResponses = places.stream()
+        List<PlaceResponse> placeResponses = placesSlice.getContent().stream()
                 .map(place -> {
                     long reviewCount = placeReviewRepository.countByPlaceId(place.getId());
 
@@ -269,19 +273,11 @@ public class VoteService {
                             votedMembers
                     );
                 })
-                .sorted((p1, p2) -> {
-                    int voteCount1 = memberPlaceVoteRepository.countByPlaceId(p1.getPlaceId());
-                    int voteCount2 = memberPlaceVoteRepository.countByPlaceId(p2.getPlaceId());
-
-                    if (voteCount1 != voteCount2) {
-                        return Integer.compare(voteCount2, voteCount1);
-                    }
-
-                    return p1.getPlaceName().compareTo(p2.getPlaceName());
-                })
                 .toList();
 
-        return new GroupPlaceResponse(groupLocation, placeResponses);
+        boolean isLast = !placesSlice.hasNext();
+
+        return new GroupPlaceResponse(groupLocation, placeResponses, isLast);
     }
 
     @Transactional


### PR DESCRIPTION
## 📌 Issue Number

- close #179 

## 🪐 작업 내용

- 카테고리 별 장소 확인 무한스크롤 구현

## ✅ PR 상세 내용

- 카테고리 별 장소 확인 무한스크롤 구현으로 수정했습니다.
- QueryDSL을 활용해 카테고리 필터링 + 투표 수 정렬 리팩토링 했습니다.

## 📸 스크린샷(선택)
![](https://github.com/user-attachments/assets/4d562949-38c0-4e26-b351-bbf1b55c97d8)

- 마지막 페이지일 때 ![](https://github.com/user-attachments/assets/a0e98e2e-2423-4783-9f64-5c0948b2c377)


## ❌ 애로 사항

- 작업하며 발생한 에러 혹은 궁금한 사항이 있다면 적어주세요.

## 📚 Reference

- 기능 구현 or 수정하며 참고한 사항이 있다면 적어주세요.
