### PR TITLE
[fix] 마이페이지/리뷰 조회 API -  코스리뷰/장소리뷰 분리

### DIFF
--- a/src/main/java/umc/catchy/domain/placeReview/dao/PlaceReviewRepositoryCustom.java
+++ b/src/main/java/umc/catchy/domain/placeReview/dao/PlaceReviewRepositoryCustom.java
@@ -12,5 +12,5 @@ public interface PlaceReviewRepositoryCustom {
     List<PostPlaceReviewResponse.placeReviewRatingResponseDTO> findRatingList(Long placeId);
     Slice<PostPlaceReviewResponse.newPlaceReviewResponseDTO> findPlaceReviewSliceByPlaceId(Long placeId, int pageSize, LocalDate lastPlaceReviewDate, Long lastPlaceReviewId);
     Optional<Double> findAverageRatingByPlaceId(Long placeId);
-    Slice<MyPageReviewsResponse.PlaceReviewDTO> getAllPlaceReviewByMemberId(Long memberId, int pageSize, Long lastPlaceReviewId);
+    Slice<MyPageReviewsResponse.PlaceReviewDTO> getAllPlaceReviewByMemberId(Long memberId, int pageSize, LocalDate lastPlaceReviewDate, Long lastPlaceReviewId);
 }

--- a/src/main/java/umc/catchy/domain/placeReview/dao/PlaceReviewRepositoryImpl.java
+++ b/src/main/java/umc/catchy/domain/placeReview/dao/PlaceReviewRepositoryImpl.java
@@ -2,6 +2,7 @@ package umc.catchy.domain.placeReview.dao;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -9,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+import umc.catchy.domain.category.domain.BigCategory;
 import umc.catchy.domain.placeReview.dto.response.PostPlaceReviewResponse;
 import umc.catchy.domain.reviewReport.dto.response.MyPageReviewsResponse;
 
@@ -20,6 +22,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.querydsl.core.group.GroupBy.*;
+import static umc.catchy.domain.category.domain.QCategory.category;
 import static umc.catchy.domain.member.domain.QMember.*;
 import static umc.catchy.domain.place.domain.QPlace.place;
 import static umc.catchy.domain.placeReview.domain.QPlaceReview.placeReview;
@@ -161,17 +164,10 @@ public class PlaceReviewRepositoryImpl implements PlaceReviewRepositoryCustom{
                                                 placeReviewImage.id.as("reviewImageId"),
                                                 placeReviewImage.imageUrl.as("imageUrl"))
                                 ).as("reviewImages"),
+                                placeReview.place.category.bigCategory.as("category"),
                                 placeReview.rating.as("rating"),
                                 placeReview.visitedDate.as("visitedDate"))
-                ))
-                .stream()
-                .peek(dto -> {
-                    // 리뷰 이미지가 null일 경우 빈 리스트로 대체
-                    if (dto.getReviewImages().get(0).getReviewImageId() == null) {
-                        dto.setReviewImages(Collections.emptyList());
-                    }
-                })
-                .collect(Collectors.toList());
+                ));
 
         return checkLastPageOfMyReviews(pageSize, results);
     }

--- a/src/main/java/umc/catchy/domain/placeReview/dao/PlaceReviewRepositoryImpl.java
+++ b/src/main/java/umc/catchy/domain/placeReview/dao/PlaceReviewRepositoryImpl.java
@@ -135,15 +135,15 @@ public class PlaceReviewRepositoryImpl implements PlaceReviewRepositoryCustom{
     }
 
     @Override
-    public Slice<MyPageReviewsResponse.PlaceReviewDTO> getAllPlaceReviewByMemberId(Long memberId, int pageSize, Long lastPlaceReviewId){
+    public Slice<MyPageReviewsResponse.PlaceReviewDTO> getAllPlaceReviewByMemberId(Long memberId, int pageSize, LocalDate lastPlaceReviewDate, Long lastPlaceReviewId){
         List<Long> reviewIds = queryFactory
                 .select(placeReview.id)
                 .from(placeReview)
                 .where(
                         memberIdEq(memberId),
-                        lastPlaceReviewId(lastPlaceReviewId)
+                        lastPlaceReviewCondition(lastPlaceReviewDate, lastPlaceReviewId)
                 )
-                .orderBy(placeReview.visitedDate.desc())
+                .orderBy(placeReview.visitedDate.desc(), placeReview.id.desc())
                 .limit(pageSize + 1)
                 .fetch();
 
@@ -153,7 +153,7 @@ public class PlaceReviewRepositoryImpl implements PlaceReviewRepositoryCustom{
                 .where(
                         placeReview.id.in(reviewIds)
                 )
-                .orderBy(placeReview.visitedDate.desc())
+                .orderBy(placeReview.visitedDate.desc(), placeReview.id.desc())
                 .transform(groupBy(placeReview.id).list(
                         Projections.fields(MyPageReviewsResponse.PlaceReviewDTO.class,
                                 placeReview.id.as("reviewId"),
@@ -174,13 +174,6 @@ public class PlaceReviewRepositoryImpl implements PlaceReviewRepositoryCustom{
 
     private BooleanExpression memberIdEq(Long memberId) {
         return memberId == null ? null : placeReview.member.id.eq(memberId);
-    }
-
-    private BooleanExpression lastPlaceReviewId(Long placeReviewId) {
-        if (placeReviewId == null) {
-            return null;
-        }
-        return placeReview.id.lt(placeReviewId);
     }
 
     private Slice<MyPageReviewsResponse.PlaceReviewDTO> checkLastPageOfMyReviews(int pageSize, List<MyPageReviewsResponse.PlaceReviewDTO> results) {

--- a/src/main/java/umc/catchy/domain/reviewReport/api/ReviewReportController.java
+++ b/src/main/java/umc/catchy/domain/reviewReport/api/ReviewReportController.java
@@ -5,6 +5,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import umc.catchy.domain.reviewReport.domain.ReviewType;
 import umc.catchy.domain.reviewReport.dto.request.PostReviewReportRequest;
 import umc.catchy.domain.reviewReport.dto.response.DeleteReviewResponse;
 import umc.catchy.domain.reviewReport.dto.response.MyPageReviewsResponse;
@@ -12,6 +13,8 @@ import umc.catchy.domain.reviewReport.dto.response.PostReviewReportResponse;
 import umc.catchy.domain.reviewReport.service.ReviewReportService;
 import umc.catchy.global.common.response.BaseResponse;
 import umc.catchy.global.common.response.status.SuccessStatus;
+
+import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
@@ -39,14 +42,24 @@ public class ReviewReportController {
         return ResponseEntity.ok(BaseResponse.onSuccess(SuccessStatus._OK, response));
     }
 
-    @Operation(summary = "마이페이지/내 리뷰 조회 API", description = "내가 작성한 리뷰를 조회하는 API입니다.")
-    @GetMapping("mypage/reviews")
-    public ResponseEntity<BaseResponse<MyPageReviewsResponse.ReviewsDTO>> getMyReviews(
-            @RequestParam String reviewType,
+    @Operation(summary = "마이페이지/내 장소 리뷰 조회 API", description = "내가 작성한 장소 리뷰를 조회하는 API입니다.")
+    @GetMapping("mypage/placeReviews")
+    public ResponseEntity<BaseResponse<MyPageReviewsResponse.ReviewsDTO>> getMyPlaceReviews(
+            @RequestParam int pageSize,
+            @RequestParam(required = false) LocalDate lastPlaceReviewDate,
+            @RequestParam(required = false) Long lastReviewId
+    ){
+        MyPageReviewsResponse.ReviewsDTO response = reviewReportService.getMyReviews("PLACE", pageSize, lastPlaceReviewDate, lastReviewId);
+        return ResponseEntity.ok(BaseResponse.onSuccess(SuccessStatus._OK, response));
+    }
+
+    @Operation(summary = "마이페이지/내 코스 리뷰 조회 API", description = "내가 작성한 코스 리뷰를 조회하는 API입니다.")
+    @GetMapping("mypage/courseReviews")
+    public ResponseEntity<BaseResponse<MyPageReviewsResponse.ReviewsDTO>> getMyCourseReviews(
             @RequestParam int pageSize,
             @RequestParam(required = false) Long lastReviewId
     ){
-        MyPageReviewsResponse.ReviewsDTO response = reviewReportService.getMyReviews(reviewType, pageSize, lastReviewId);
+        MyPageReviewsResponse.ReviewsDTO response = reviewReportService.getMyReviews("COURSE", pageSize, null, lastReviewId);
         return ResponseEntity.ok(BaseResponse.onSuccess(SuccessStatus._OK, response));
     }
 }

--- a/src/main/java/umc/catchy/domain/reviewReport/dto/response/MyPageReviewsResponse.java
+++ b/src/main/java/umc/catchy/domain/reviewReport/dto/response/MyPageReviewsResponse.java
@@ -1,6 +1,7 @@
 package umc.catchy.domain.reviewReport.dto.response;
 
 import lombok.*;
+import umc.catchy.domain.category.domain.BigCategory;
 import umc.catchy.domain.course.domain.CourseType;
 import umc.catchy.domain.reviewReport.domain.ReviewType;
 
@@ -34,7 +35,7 @@ public class MyPageReviewsResponse {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class PlaceReviewDTO extends BaseReviewDTO {
-        //TODO 카테고리 리스트
+        BigCategory category;
         Integer rating;
         LocalDate visitedDate;
     }

--- a/src/main/java/umc/catchy/domain/reviewReport/service/ReviewReportService.java
+++ b/src/main/java/umc/catchy/domain/reviewReport/service/ReviewReportService.java
@@ -27,6 +27,7 @@ import umc.catchy.global.error.exception.GeneralException;
 import umc.catchy.global.util.SecurityUtil;
 import umc.catchy.infra.aws.s3.AmazonS3Manager;
 
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -67,14 +68,14 @@ public class ReviewReportService {
     }
 
     //마이페이지 : 내 리뷰 조회
-    public MyPageReviewsResponse.ReviewsDTO getMyReviews(String reviewType, int pageSize, Long lastReviewId){
+    public MyPageReviewsResponse.ReviewsDTO getMyReviews(String reviewType, int pageSize, LocalDate lastPlaceReviewDate, Long lastReviewId){
         Long memberId = SecurityUtil.getCurrentMemberId();
         ReviewType type = parseReviewType(reviewType);
 
         if(type==ReviewType.PLACE){
             Integer totalCount = placeReviewRepository.countAllByMemberId(memberId);
             Slice<MyPageReviewsResponse.PlaceReviewDTO> placeReviewResponse
-                    = placeReviewRepository.getAllPlaceReviewByMemberId(memberId, pageSize, lastReviewId);
+                    = placeReviewRepository.getAllPlaceReviewByMemberId(memberId, pageSize, lastPlaceReviewDate, lastReviewId);
             List<MyPageReviewsResponse.PlaceReviewDTO> content = placeReviewResponse.getContent();
             Boolean last = placeReviewResponse.isLast();
             return toReviewsDTO(type, totalCount, content, last);


### PR DESCRIPTION
## 📌 Issue Number

- close #186 

## 🪐 작업 내용

- 장소리뷰 조회, 카테고리를 response에 추가
- 장소리뷰 조회/코스리뷰 조회 API 분리 - 마이페이지

## ✅ PR 상세 내용

- response 수정
- API 분리 및 장소 리뷰 정렬 방식 수정

## 📸 스크린샷(선택)
- 코스 리뷰
![image](https://github.com/user-attachments/assets/3d9410ce-1777-4007-907c-0e649dc77587)

- 장소 리뷰 
![image](https://github.com/user-attachments/assets/531c981b-f366-44b2-b5e4-30207e76cb7c)
![image](https://github.com/user-attachments/assets/d45ee04e-2b0a-491f-b440-f1ed9ea029ed)

## ❌ 애로 사항
## 📚 Reference