### PR TITLE
[feature] redis를 통한 refreshToken 관리

### DIFF
--- a/src/main/java/umc/catchy/domain/jwt/service/BlackTokenRedisService.java
+++ b/src/main/java/umc/catchy/domain/jwt/service/BlackTokenRedisService.java
@@ -1,0 +1,35 @@
+package umc.catchy.domain.jwt.service;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BlackTokenRedisService {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Value("${cache.blacklist.key}")
+    private String REDIS_BLACKLIST_KEY_PREFIX;
+
+    // 블랙리스트 토큰 저장
+    public void addBlacklistedToken(String token, long expiration) {
+        String key = REDIS_BLACKLIST_KEY_PREFIX + token;
+        redisTemplate.opsForValue().set(key, token, expiration, TimeUnit.MILLISECONDS);
+    }
+
+    // 블랙리스트 토큰 유효성 검사
+    public boolean isTokenBlacklisted(String token) {
+        String key = REDIS_BLACKLIST_KEY_PREFIX + token;
+        String storedToken = redisTemplate.opsForValue().get(key);
+        return storedToken != null;
+    }
+
+    // 블랙리스트 토큰 제거
+    public void deleteBlacklistedToken(String token) {
+        String key = REDIS_BLACKLIST_KEY_PREFIX + token;
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/umc/catchy/domain/jwt/service/BlackTokenRedisService.java
+++ b/src/main/java/umc/catchy/domain/jwt/service/BlackTokenRedisService.java
@@ -24,7 +24,7 @@ public class BlackTokenRedisService {
     public boolean isTokenBlacklisted(String token) {
         String key = REDIS_BLACKLIST_KEY_PREFIX + token;
         String storedToken = redisTemplate.opsForValue().get(key);
-        return storedToken != null;
+        return storedToken != null && storedToken.equals(token);
     }
 
     // 블랙리스트 토큰 제거

--- a/src/main/java/umc/catchy/domain/jwt/service/RedisTokenService.java
+++ b/src/main/java/umc/catchy/domain/jwt/service/RedisTokenService.java
@@ -1,0 +1,44 @@
+package umc.catchy.domain.jwt.service;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RedisTokenService {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Value("${cache.refreshToken.key}")
+    private String REDIS_REFRESH_TOKEN_KEY_PREFIX;
+
+    @Value("${cache.refreshToken.ttl}")
+    private long EXPIRATION;
+
+    // 리프레시 토큰 저장
+    public void addRefreshToken(String refreshToken, Long memberId) {
+        String key = REDIS_REFRESH_TOKEN_KEY_PREFIX + memberId;
+        redisTemplate.opsForValue().set(key, refreshToken, EXPIRATION, TimeUnit.SECONDS);
+    }
+
+    // 리프레시 토큰 유효성 검사
+    public boolean isRefreshTokenValid(String refreshToken, Long memberId) {
+        String key = REDIS_REFRESH_TOKEN_KEY_PREFIX + memberId;
+        String storedUserId = redisTemplate.opsForValue().get(key);
+        return !storedUserId.isBlank();
+    }
+
+    // 리프레시 토큰 삭제
+    public void deleteRefreshToken(Long memberId) {
+        String key = REDIS_REFRESH_TOKEN_KEY_PREFIX + memberId;
+        redisTemplate.delete(key);
+    }
+
+    // 리프레시 토큰 찾기
+    public String getRefreshToken(Long memberId) {
+        String key = REDIS_REFRESH_TOKEN_KEY_PREFIX + memberId;
+        return redisTemplate.opsForValue().get(key);
+    }
+}

--- a/src/main/java/umc/catchy/domain/jwt/service/RedisTokenService.java
+++ b/src/main/java/umc/catchy/domain/jwt/service/RedisTokenService.java
@@ -27,7 +27,7 @@ public class RedisTokenService {
     public boolean isRefreshTokenValid(String refreshToken, Long memberId) {
         String key = REDIS_REFRESH_TOKEN_KEY_PREFIX + memberId;
         String storedToken = redisTemplate.opsForValue().get(key);
-        return !storedToken.equals(refreshToken);
+        return storedToken != null && storedToken.equals(refreshToken);
     }
 
     // 리프레시 토큰 삭제

--- a/src/main/java/umc/catchy/domain/jwt/service/RedisTokenService.java
+++ b/src/main/java/umc/catchy/domain/jwt/service/RedisTokenService.java
@@ -26,8 +26,8 @@ public class RedisTokenService {
     // 리프레시 토큰 유효성 검사
     public boolean isRefreshTokenValid(String refreshToken, Long memberId) {
         String key = REDIS_REFRESH_TOKEN_KEY_PREFIX + memberId;
-        String storedUserId = redisTemplate.opsForValue().get(key);
-        return !storedUserId.isBlank();
+        String storedToken = redisTemplate.opsForValue().get(key);
+        return !storedToken.equals(refreshToken);
     }
 
     // 리프레시 토큰 삭제

--- a/src/main/java/umc/catchy/domain/mapping/placeLike/dao/PlaceLikeRepository.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeLike/dao/PlaceLikeRepository.java
@@ -11,4 +11,5 @@ import umc.catchy.domain.place.domain.Place;
 @Repository
 public interface PlaceLikeRepository extends JpaRepository<PlaceLike, Long> {
     Optional<PlaceLike> findByPlaceAndMember(Place place, Member member);
+    Integer deleteAllByMember(Member member);
 }

--- a/src/main/java/umc/catchy/domain/mapping/placeVisit/dao/PlaceVisitRepository.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeVisit/dao/PlaceVisitRepository.java
@@ -22,4 +22,5 @@ public interface PlaceVisitRepository extends JpaRepository<PlaceVisit, Long> {
     List<PlaceVisit> findPlaceVisitsByMemberAndPlaces(@Param("memberId") Long memberId, @Param("placeIds") List<Long> placeIds);
     List<PlaceVisit> findAllByMemberAndPlaceAndIsVisitedTrue(Member member, Place place);
     List<PlaceVisit> findAllByMemberOrderByVisitedDateDesc(Member member);
+    Integer deleteAllByMember(Member member);
 }

--- a/src/main/java/umc/catchy/domain/member/dao/MemberRepository.java
+++ b/src/main/java/umc/catchy/domain/member/dao/MemberRepository.java
@@ -10,6 +10,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByProviderId(String providerId);
     Optional<Member> findByNickname(String nickname);
     Optional<Member> findByEmailAndProviderId(String email, String providerId);
-    Optional<Member> findByRefreshToken(String refreshToken);
     Optional<Member> findByAccessToken(String accessToken);
 }

--- a/src/main/java/umc/catchy/domain/member/domain/Member.java
+++ b/src/main/java/umc/catchy/domain/member/domain/Member.java
@@ -41,9 +41,6 @@ public class Member extends BaseTimeEntity {
     private String accessToken;
 
     @Setter
-    private String refreshToken;
-
-    @Setter
     private String authorizationCode;
 
     @Column(nullable = false)

--- a/src/main/java/umc/catchy/domain/member/dto/response/SignUpResponse.java
+++ b/src/main/java/umc/catchy/domain/member/dto/response/SignUpResponse.java
@@ -13,7 +13,7 @@ public record SignUpResponse(
         String accessToken,
         String refreshToken
 ) {
-    public static SignUpResponse of(Member member) {
+    public static SignUpResponse of(Member member, String refreshToken) {
         return new SignUpResponse(
                 member.getId(),
                 member.getProviderId(),
@@ -22,7 +22,7 @@ public record SignUpResponse(
                 member.getProfileImage(),
                 member.getCreatedDate(),
                 member.getAccessToken(),
-                member.getRefreshToken()
+                refreshToken
         );
     }
 

--- a/src/main/java/umc/catchy/domain/member/service/MemberService.java
+++ b/src/main/java/umc/catchy/domain/member/service/MemberService.java
@@ -81,6 +81,8 @@ import umc.catchy.domain.mapping.memberLocation.dto.response.MemberLocationCreat
 import umc.catchy.domain.mapping.memberPlaceVote.dao.MemberPlaceVoteRepository;
 import umc.catchy.domain.mapping.memberStyle.dao.MemberStyleRepository;
 import umc.catchy.domain.mapping.memberStyle.domain.MemberStyle;
+import umc.catchy.domain.mapping.placeLike.dao.PlaceLikeRepository;
+import umc.catchy.domain.mapping.placeVisit.dao.PlaceVisitRepository;
 import umc.catchy.domain.member.dao.MemberRepository;
 import umc.catchy.domain.member.domain.Member;
 import umc.catchy.domain.member.domain.SocialType;
@@ -121,6 +123,8 @@ public class MemberService {
     private final MemberCategoryVoteRepository memberCategoryVoteRepository;
     private final RedisTokenService redisTokenService;
     private final BlackTokenRedisService blackTokenRedisService;
+    private final PlaceVisitRepository placeVisitRepository;
+    private final PlaceLikeRepository placeLikeRepository;
 
     @Value("${security.kakao.client-id}")
     private String KAKAO_CLIENT_ID;
@@ -216,7 +220,7 @@ public class MemberService {
 
         memberRepository.save(newMember);
 
-        return SignUpResponse.of(newMember);
+        return SignUpResponse.of(newMember, refreshToken);
     }
 
     public LoginResponse login(LoginRequest request, SocialType socialType) {
@@ -427,6 +431,8 @@ public class MemberService {
         memberGroupRepository.deleteAllByMember(member);
         memberCourseRepository.deleteAllByMember(member);
         memberCategoryRepository.deleteAllByMember(member);
+        placeVisitRepository.deleteAllByMember(member);
+        placeLikeRepository.deleteAllByMember(member);
 
         // 기존 토큰들 무효화
         String originAccessToken = member.getAccessToken();

--- a/src/main/java/umc/catchy/domain/member/service/MemberService.java
+++ b/src/main/java/umc/catchy/domain/member/service/MemberService.java
@@ -253,8 +253,6 @@ public class MemberService {
 
         if (refreshToken == null) throw new GeneralException(ErrorStatus.NOT_FOUND_TOKEN);
 
-        System.out.println(refreshToken);
-
         // 리프레시 토큰 만료 검사
         boolean isValid = redisTokenService.isRefreshTokenValid(refreshToken, memberId);
 
@@ -306,7 +304,6 @@ public class MemberService {
 
             //결과 코드가 200이라면 성공
             int responseCode = conn.getResponseCode();
-            System.out.println("responseCode : " + responseCode);
 
             if (responseCode != 200) {
                 BufferedReader errorReader = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
@@ -315,7 +312,6 @@ public class MemberService {
                 while ((errorLine = errorReader.readLine()) != null) {
                     errorResult.append(errorLine);
                 }
-                System.out.println("Error response body: " + errorResult.toString());
                 errorReader.close();
             }
 
@@ -327,7 +323,6 @@ public class MemberService {
             while ((line = br.readLine()) != null) {
                 result += line;
             }
-            System.out.println("response body : " + result);
 
             //Gson 라이브러리에 포함된 클래스로 JSON파싱 객체 생성
             JsonParser parser = new JsonParser();
@@ -335,9 +330,6 @@ public class MemberService {
 
             access_Token = element.getAsJsonObject().get("access_token").getAsString();
             refresh_Token = element.getAsJsonObject().get("refresh_token").getAsString();
-
-            System.out.println("access_token : " + access_Token);
-            System.out.println("refresh_token : " + refresh_Token);
 
             br.close();
             bw.close();
@@ -420,7 +412,6 @@ public class MemberService {
             try {
                 appleWithdraw(authorizationCode);
             } catch (IOException e) {
-                System.out.println(e.getMessage());
                 throw new GeneralException(ErrorStatus.APPLE_WITHDRAW_FAILED);
             } catch (net.minidev.json.parser.ParseException e) {
                 throw new RuntimeException(e);
@@ -505,9 +496,6 @@ public class MemberService {
 
             conn.setRequestProperty("Authorization", "Bearer " + token);
 
-            int responseCode = conn.getResponseCode();
-            System.out.println("responseCode : " + responseCode);
-
             BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
             String line = "";
             StringBuilder result = new StringBuilder();
@@ -515,7 +503,6 @@ public class MemberService {
             while ((line = br.readLine()) != null) {
                 result.append(line);
             }
-            System.out.println("response body : " + result);
 
             JsonElement element = JsonParser.parseString(result.toString());
             String providerId = String.valueOf(element.getAsJsonObject().get("id"));

--- a/src/main/java/umc/catchy/global/common/response/status/ErrorStatus.java
+++ b/src/main/java/umc/catchy/global/common/response/status/ErrorStatus.java
@@ -61,6 +61,7 @@ public enum ErrorStatus implements BaseErrorCode {
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "TOKEN401", "만료된 토큰입니다."),
     UNSUPPORTED_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN402", "지원하지 않는 형식의 토큰입니다."),
     NOT_FOUND_TOKEN(HttpStatus.NOT_FOUND, "TOKEN404", "토큰의 클레임이 비어있습니다."),
+    BLACKLISTED_TOKEN(HttpStatus.UNAUTHORIZED, "BLACKLIST_TOKEN", "만료된 액세스토큰 입니다."),
 
     // 투표 관련 에러
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "VOTE404", "해당 카테고리를 찾을 수 없습니다."),

--- a/src/main/java/umc/catchy/global/util/JwtUtil.java
+++ b/src/main/java/umc/catchy/global/util/JwtUtil.java
@@ -1,5 +1,7 @@
 package umc.catchy.global.util;
 
+import io.jsonwebtoken.Jwts;
+import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import umc.catchy.domain.jwt.domain.JwtTokenProvider;
@@ -38,5 +40,13 @@ public class JwtUtil {
                 new GeneralException(ErrorStatus.MEMBER_NOT_FOUND)
         );
         return member.getId();
+    }
+
+    public Date getExpirationTime(String accessToken) {
+        return Jwts.parser()
+                .setSigningKey(jwtProperties.getSecret())
+                .parseClaimsJws(accessToken)
+                .getBody()
+                .getExpiration();
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,7 +4,7 @@ spring:
       enabled: true
       path: /h2-console
   datasource:
-    url: jdbc:h2:~/catchy;AUTO_SERVER=TRUE;MODE=MySQL;
+    url: jdbc:h2:tcp://localhost/~/catchy
     username: sa
     password:
     driver-class-name: org.h2.Driver

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,7 +4,7 @@ spring:
       enabled: true
       path: /h2-console
   datasource:
-    url: jdbc:h2:tcp://localhost/~/catchy
+    url: jdbc:h2:~/catchy;AUTO_SERVER=TRUE;MODE=MySQL;
     username: sa
     password:
     driver-class-name: org.h2.Driver
@@ -74,3 +74,8 @@ cache:
   recommended-courses:
     key: ${REDIS_CACHE_KEY}
     ttl: 86400 #1일
+  refreshToken:
+    key: ${REDIS_TOKEN_KEY}
+    ttl: 604800 #1주일
+  blacklist:
+    key: ${REDIS_BLACKLIST_KEY}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -74,6 +74,11 @@ cache:
   recommended-courses:
     key: ${REDIS_CACHE_KEY}
     ttl: 604800  # 7일
+  refreshToken:
+    key: ${REDIS_TOKEN_KEY}
+    ttl: 604800 #1주일
+  blacklist:
+    key: ${REDIS_BLACKLIST_KEY}
 
 server:
   port: 8081


### PR DESCRIPTION
## 📌 Issue Number

- close #177 

## 🪐 작업 내용

- 효율적으로 DB를 활용하기 위해 redis를 사용했습니다.
- 액세스 토큰은 db에서, 리프레시 토큰은 redis에서 관리

## ✅ PR 상세 내용

- 회원가입: 리프레시 토큰 redis 저장
- 로그인: 기존 리프레시 토큰 redis 삭제, 새 액세스 토큰 db저장, 새 리프레시 토큰 redis 저장
- 로그아웃: 리프레시 토큰 redis 삭제, 액세스 토큰 블랙리스트(redis)
- 토큰 재발급: 기존 토큰 무효화(각각 redis 삭제, 블랙리스트 추가), 새로운 토큰 저장(각각 redis, db 저장) 
- 회원탈퇴: 기존 토큰 무효화

## 📸 스크린샷(선택)

<img width="242" alt="image" src="https://github.com/user-attachments/assets/5a5ab893-bd3b-42c9-9e3d-6f226e064552" />

Key 값을 통해 redis에 잘 저장되는거 확인


## 📚 Reference

https://eesko.tistory.com/353
https://onethejay.tistory.com/34
