### PR TITLE
[chore] 도커 이미지 사이즈 최적화

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM openjdk:17
+FROM eclipse-temurin:17-jdk-alpine
+
+# glibc 호환성을 위한 gcompat 설치
+RUN apk add --no-cache gcompat
 
 # 애플리케이션 JAR 파일을 컨테이너로 복사
 ARG JAR_FILE=./build/libs/*.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,21 @@
-FROM eclipse-temurin:17-jdk-alpine
+# 1단계 : 빌드 환경
+FROM eclipse-temurin:17-jdk-alpine AS builder
 
-# glibc 호환성을 위한 gcompat 설치
-RUN apk add --no-cache gcompat
+# 작업 디렉토리 설정
+WORKDIR /app
 
 # 애플리케이션 JAR 파일을 컨테이너로 복사
 ARG JAR_FILE=./build/libs/*.jar
 COPY ${JAR_FILE} /app.jar
+
+# 2단계 : 실행 환경
+FROM eclipse-temurin:17-jre-alpine
+
+# glibc 호환성을 위한 gcompat 설치
+RUN apk add --no-cache gcompat
+
+# 빌드된 JAR 파일을 복사
+COPY --from=builder /app.jar /app.jar
 
 # Spring 프로파일 설정
 ENV SPRING_PROFILES_ACTIVE=prod


### PR DESCRIPTION
## 📌 Issue Number

- close #198 

## 🪐 작업 내용

- Dockerfile 수정을 통한 이미지 사이즈 최적화 수행

## ✅ PR 상세 내용

- 도커 빌드 이미지 베이스 변경
openjdk:17 ▶️ eclipse-temurin:17-jdk-alpine
- 멀티 스테이지 빌드 적용
eclipse-temurin:17-jdk-alpine & eclipse-temurin:17-jre-alpine
443.39MB ▶️ 291.79MB

## 📸 스크린샷(선택)
1. 도커 빌드 이미지 베이스 변경 : 같은 빌드 파일로부터 139.49MB 만큼 사이즈를 줄임. & 기능 수행이 잘 되는 것 또한 확인.
![image](https://github.com/user-attachments/assets/2e680220-ff66-4f57-834b-33ad3f1225a0)
![image](https://github.com/user-attachments/assets/5b99c709-f727-4b5c-9b74-6ce6c257cd04)
![image](https://github.com/user-attachments/assets/d4abc260-5173-47b4-b83d-a4bea9db168a)

2. 멀티 스테이지 빌드 적용 : 이미지 사이즈를 151.6MB 만큼 줄임. & 기능 수행이 잘 되는 것을 확인
![image](https://github.com/user-attachments/assets/e27473ad-be0d-48c0-adbd-e105945dcae8)
![image](https://github.com/user-attachments/assets/0d9d34f0-afb4-4114-8a6a-5f1c922d4dc5)


## ❌ 애로 사항
빌드 후 배포 환경 테스트에서 로그인 / 인기코스 조회 / S3 업로드 및 삭제 API를 통해 기능 수행을 확인함.
만약 배포 환경에서 API 실행했을 때 서버가 터진다면 알려주세요~

## 📚 Reference
- https://octoping.tistory.com/58
- GPT
