### PR TITLE
[fix] category 존재하지 않을 시 null 반환하도록 변경

### DIFF
--- a/src/main/java/umc/catchy/domain/place/converter/PlaceConverter.java
+++ b/src/main/java/umc/catchy/domain/place/converter/PlaceConverter.java
@@ -28,7 +28,7 @@ public class PlaceConverter {
     }
 
     public static PlaceInfoPreview toPlaceInfoPreview(Place place, Long reviewCount) {
-        String categoryName = "";
+        String categoryName = null;
         Double rating = 0.0;
 
         if (place.getCategory() != null) {
@@ -52,7 +52,7 @@ public class PlaceConverter {
     }
 
     public static PlaceInfoDetail toPlaceInfoDetail (Place place, Long reviewCount, Boolean isVisited, Boolean isLiked) {
-        String categoryName = "";
+        String categoryName = null;
         Double rating = 0.0;
 
         if (place.getCategory() != null) {


### PR DESCRIPTION
## 📌 Issue Number

- close #201 

## 🪐 작업 내용

- category 존재하지 않을 시 null 반환하도록 변경

## ✅ PR 상세 내용

- place에서 없는 값은 null로 통일

