### PR TITLE
[feature] 장소이름/카테고리 검색을 통한 장소 검색

### DIFF
--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/dto/response/PlaceInfoContainRelevance.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/dto/response/PlaceInfoContainRelevance.java
@@ -1,0 +1,16 @@
+package umc.catchy.domain.mapping.placeCourse.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PlaceInfoContainRelevance {
+    private PlaceInfoResponse placeInfoResponse;
+    private Integer relevanceScore;
+}

--- a/src/main/java/umc/catchy/domain/mapping/placeCourse/dto/response/PlaceInfoContainRelevanceScoreSliceResponse.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeCourse/dto/response/PlaceInfoContainRelevanceScoreSliceResponse.java
@@ -1,0 +1,15 @@
+package umc.catchy.domain.mapping.placeCourse.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+public record PlaceInfoContainRelevanceScoreSliceResponse(
+        @Schema(description = "장소(검색어 가중치를 더한) 데이터") List<PlaceInfoContainRelevance> content,
+        @Schema(description = "마지막 페이지 여부") Boolean last){
+
+        public static PlaceInfoContainRelevanceScoreSliceResponse from(Slice<PlaceInfoContainRelevance> placeInfoResponses) {
+                return new PlaceInfoContainRelevanceScoreSliceResponse(placeInfoResponses.getContent(),placeInfoResponses.isLast());
+    }
+}

--- a/src/main/java/umc/catchy/domain/place/api/PlaceController.java
+++ b/src/main/java/umc/catchy/domain/place/api/PlaceController.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoContainRelevanceScoreSliceResponse;
 import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoPreviewSliceResponse;
 import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoSliceResponse;
 import umc.catchy.domain.mapping.placeLike.dto.response.PlaceLikedResponse;
@@ -87,12 +88,13 @@ public class PlaceController {
 
     @Operation(summary = "장소 검색 API", description = "장소이름/카테고리를 통해 장소 리스트 반환")
     @GetMapping("/home/search")
-    public ResponseEntity<BaseResponse<PlaceInfoSliceResponse>> getSearchPlaces(
+    public ResponseEntity<BaseResponse<PlaceInfoContainRelevanceScoreSliceResponse>> getSearchPlaces(
             @RequestParam(required = false) String keyword,
             @RequestParam int pageSize,
+            @RequestParam(required = false) Integer relevanceScore,
             @RequestParam(required = false) Long lastPlaceId
     ) {
-        PlaceInfoSliceResponse response = placeService.searchPlaceByCategoryOrName(pageSize,keyword,lastPlaceId);
+        PlaceInfoContainRelevanceScoreSliceResponse response = placeService.searchPlaceByCategoryOrName(pageSize,keyword,relevanceScore,lastPlaceId);
         return ResponseEntity.ok(BaseResponse.onSuccess(SuccessStatus._OK, response));
     }
 }

--- a/src/main/java/umc/catchy/domain/place/api/PlaceController.java
+++ b/src/main/java/umc/catchy/domain/place/api/PlaceController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoPreviewSliceResponse;
+import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoSliceResponse;
 import umc.catchy.domain.mapping.placeLike.dto.response.PlaceLikedResponse;
 import umc.catchy.domain.mapping.placeLike.service.PlaceLikeService;
 import umc.catchy.domain.mapping.placeVisit.dto.response.PlaceVisitedDateResponse;
@@ -81,6 +82,17 @@ public class PlaceController {
             @RequestParam int page
     ) {
         PlaceInfoPreviewSliceResponse response = placeService.recommendPlaces(latitude, longitude, pageSize, page);
+        return ResponseEntity.ok(BaseResponse.onSuccess(SuccessStatus._OK, response));
+    }
+
+    @Operation(summary = "장소 검색 API", description = "장소이름/카테고리를 통해 장소 리스트 반환")
+    @GetMapping("/home/search")
+    public ResponseEntity<BaseResponse<PlaceInfoSliceResponse>> getSearchPlaces(
+            @RequestParam(required = false) String keyword,
+            @RequestParam int pageSize,
+            @RequestParam(required = false) Long lastPlaceId
+    ) {
+        PlaceInfoSliceResponse response = placeService.searchPlaceByCategoryOrName(pageSize,keyword,lastPlaceId);
         return ResponseEntity.ok(BaseResponse.onSuccess(SuccessStatus._OK, response));
     }
 }

--- a/src/main/java/umc/catchy/domain/place/dao/PlaceCustomRepository.java
+++ b/src/main/java/umc/catchy/domain/place/dao/PlaceCustomRepository.java
@@ -3,6 +3,7 @@ package umc.catchy.domain.place.dao;
 import java.util.Map;
 import org.springframework.data.domain.Slice;
 import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoPreview;
+import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoResponse;
 import umc.catchy.domain.place.domain.Place;
 
 import java.util.List;
@@ -11,4 +12,5 @@ public interface PlaceCustomRepository {
     List<Place> findPlacesByDynamicFilters(List<Long> categoryIds, List<String> upperRegions, List<String> lowerRegions);
     List<Place> findRecommendedPlaces(List<Long> categoryIds, List<String> upperRegions, List<String> lowerRegions, Long memberId, int maxPlaces);
     Slice<PlaceInfoPreview> recommendPlacesByActivityData(Long memberId, Double latitude, Double longitude, List<Long> categoryIds, Map<Long, Integer> hourMap, int pageSize, int page);
+    Slice<PlaceInfoResponse> searchPlace(int pageSize, String keyword, Long lastPlaceId);
 }

--- a/src/main/java/umc/catchy/domain/place/dao/PlaceCustomRepository.java
+++ b/src/main/java/umc/catchy/domain/place/dao/PlaceCustomRepository.java
@@ -2,6 +2,7 @@ package umc.catchy.domain.place.dao;
 
 import java.util.Map;
 import org.springframework.data.domain.Slice;
+import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoContainRelevance;
 import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoPreview;
 import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoResponse;
 import umc.catchy.domain.place.domain.Place;
@@ -12,5 +13,5 @@ public interface PlaceCustomRepository {
     List<Place> findPlacesByDynamicFilters(List<Long> categoryIds, List<String> upperRegions, List<String> lowerRegions);
     List<Place> findRecommendedPlaces(List<Long> categoryIds, List<String> upperRegions, List<String> lowerRegions, Long memberId, int maxPlaces);
     Slice<PlaceInfoPreview> recommendPlacesByActivityData(Long memberId, Double latitude, Double longitude, List<Long> categoryIds, Map<Long, Integer> hourMap, int pageSize, int page);
-    Slice<PlaceInfoResponse> searchPlace(int pageSize, String keyword, Long lastPlaceId);
+    Slice<PlaceInfoContainRelevance> searchPlace(int pageSize, String keyword, Integer lastRelevanceScore, Long lastPlaceId);
 }

--- a/src/main/java/umc/catchy/domain/place/dao/PlaceRepositoryImpl.java
+++ b/src/main/java/umc/catchy/domain/place/dao/PlaceRepositoryImpl.java
@@ -19,6 +19,7 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -300,6 +301,11 @@ public class PlaceRepositoryImpl implements PlaceCustomRepository {
                 latitude, place.latitude, place.longitude, longitude);
          */
 
+        // 키워드가 없으면 바로 빈 리스트 반환
+        if (keyword == null || keyword.trim().isEmpty()) {
+            return new SliceImpl<>(Collections.emptyList(), PageRequest.of(0, pageSize), false);
+        }
+
         NumberExpression<Integer> relevanceScore = getRelevanceScore(keyword);
 
         List<PlaceInfoContainRelevance> results = queryFactory.select(
@@ -361,6 +367,10 @@ public class PlaceRepositoryImpl implements PlaceCustomRepository {
     }
 
     private Slice<PlaceInfoContainRelevance> checkLastPage(int pageSize, List<PlaceInfoContainRelevance> results) {
+        if (results.isEmpty()) {
+            return new SliceImpl<>(Collections.emptyList(), PageRequest.of(0, pageSize), false);
+        }
+
         boolean hasNext = false;
 
         if (results.size() > pageSize) {

--- a/src/main/java/umc/catchy/domain/place/service/PlaceService.java
+++ b/src/main/java/umc/catchy/domain/place/service/PlaceService.java
@@ -16,6 +16,8 @@ import umc.catchy.domain.category.domain.BigCategory;
 import umc.catchy.domain.category.domain.Category;
 import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoPreview;
 import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoPreviewSliceResponse;
+import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoResponse;
+import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoSliceResponse;
 import umc.catchy.domain.mapping.placeVisit.dao.PlaceVisitRepository;
 import umc.catchy.domain.mapping.placeVisit.domain.PlaceVisit;
 import umc.catchy.domain.member.dao.MemberRepository;
@@ -75,6 +77,11 @@ public class PlaceService {
         Slice<PlaceInfoPreview> placeInfoPreviews = placeRepository.recommendPlacesByActivityData(memberId, latitude, longitude, sortedVisitCategories, categoryAverageHour, pageSize, page);
 
         return PlaceInfoPreviewSliceResponse.from(placeInfoPreviews);
+    }
+
+    public PlaceInfoSliceResponse searchPlaceByCategoryOrName(int pageSize, String keyword, Long lastPlaceId) {
+        Slice<PlaceInfoResponse> responses = placeRepository.searchPlace(pageSize, keyword, lastPlaceId);
+        return PlaceInfoSliceResponse.from(responses);
     }
 
     private Map<Long, Integer> getCategoryAverageHour(List<PlaceVisit> placeVisits) {

--- a/src/main/java/umc/catchy/domain/place/service/PlaceService.java
+++ b/src/main/java/umc/catchy/domain/place/service/PlaceService.java
@@ -14,10 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import umc.catchy.domain.category.dao.CategoryRepository;
 import umc.catchy.domain.category.domain.BigCategory;
 import umc.catchy.domain.category.domain.Category;
-import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoPreview;
-import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoPreviewSliceResponse;
-import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoResponse;
-import umc.catchy.domain.mapping.placeCourse.dto.response.PlaceInfoSliceResponse;
+import umc.catchy.domain.mapping.placeCourse.dto.response.*;
 import umc.catchy.domain.mapping.placeVisit.dao.PlaceVisitRepository;
 import umc.catchy.domain.mapping.placeVisit.domain.PlaceVisit;
 import umc.catchy.domain.member.dao.MemberRepository;
@@ -79,9 +76,9 @@ public class PlaceService {
         return PlaceInfoPreviewSliceResponse.from(placeInfoPreviews);
     }
 
-    public PlaceInfoSliceResponse searchPlaceByCategoryOrName(int pageSize, String keyword, Long lastPlaceId) {
-        Slice<PlaceInfoResponse> responses = placeRepository.searchPlace(pageSize, keyword, lastPlaceId);
-        return PlaceInfoSliceResponse.from(responses);
+    public PlaceInfoContainRelevanceScoreSliceResponse searchPlaceByCategoryOrName(int pageSize, String keyword, Integer lastRelevanceScore, Long lastPlaceId) {
+        Slice<PlaceInfoContainRelevance> responses = placeRepository.searchPlace(pageSize, keyword, lastRelevanceScore ,lastPlaceId);
+        return PlaceInfoContainRelevanceScoreSliceResponse.from(responses);
     }
 
     private Map<Long, Integer> getCategoryAverageHour(List<PlaceVisit> placeVisits) {


### PR DESCRIPTION
## 📌 Issue Number

- close #169 

## 🪐 작업 내용

- 홈 화면 기능인 장소이름/카테고리이름으로 장소를 검색하는 기능 API 입니다.

## ✅ PR 상세 내용

- 검색어가 장소명이랑 아예 일치하면 관련성 100점, 장소명이 포함되면 80점, 카테고리가 일치하면 60점, 카테고리를 포함하면 40점, 아무것도 일치하지 않으면 0점으로 관련도를 파악했습니다.
- query string 으로 마지막 장소Id와 해당장소와 검색어간의 연관도를 입력받아 다음 Page를 가져올 수 있습니다.
- 정렬순은 연관도를 우선으로 정렬하였고, 연관도가 일치하는경우 PlaceId를 기준으로 내림차순으로 정렬하였습니다.
## 📸 스크린샷(선택)

<img width="356" alt="image" src="https://github.com/user-attachments/assets/698ef375-e79e-446c-939a-1bb31330942c" />

<img width="380" alt="image" src="https://github.com/user-attachments/assets/65d01945-8503-437f-a0f2-820d87baa1f6" />

키워드가 없거나, 해당 키워드를 포함하는 장소 데이터가 없는경우 
<img width="248" alt="image" src="https://github.com/user-attachments/assets/48e62340-a5ca-4a33-833b-67fd0acfbbfc" />


## ❌ 애로 사항

- 현재 검색어로 장소이름을 포함하거나 일치하는 경우, 카테고리가 일치하거나 포함하는 경우는 데이터로 불러올 수 있습니다. 하지만 유사한 장소명 또는 연관 장소는 불러오지 못합니다. 이는 현재 기술적 문제로 나중에 Elastic Search를 도입해 검색 성능을 더욱 개선하도록 해야겠습니다.

## 📚 Reference

- 