### PR TITLE
[fix] 코스 상세 조회 : 각 장소 별 카테고리 response에 추가

### DIFF
--- a/src/main/java/umc/catchy/domain/course/dto/response/CourseInfoResponse.java
+++ b/src/main/java/umc/catchy/domain/course/dto/response/CourseInfoResponse.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import umc.catchy.domain.category.domain.BigCategory;
 import umc.catchy.domain.course.domain.CourseType;
 
 import java.util.List;
@@ -35,6 +36,7 @@ public class CourseInfoResponse {
     public static class getPlaceInfoOfCourseDTO{
         Long placeId;
         String placeName;
+        BigCategory category;
         Double placeLatitude;
         Double placeLongitude;
         Boolean isVisited;

--- a/src/main/java/umc/catchy/domain/place/converter/PlaceConverter.java
+++ b/src/main/java/umc/catchy/domain/place/converter/PlaceConverter.java
@@ -21,6 +21,7 @@ public class PlaceConverter {
                 .builder()
                 .placeId(place.getId())
                 .placeName(place.getPlaceName())
+                .category(place.getCategory().getBigCategory())
                 .placeLatitude(place.getLatitude())
                 .placeLongitude(place.getLongitude())
                 .isVisited(isVisited)


### PR DESCRIPTION
## 📌 Issue Number

- close #221 

## 🪐 작업 내용

- 코스 상세 조회 시, 코스의 각 장소의 카테고리를 조회할 수 있도록 함.

## ✅ PR 상세 내용

- dto 및 converter 수정

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/72ba83a0-6727-4ea7-9b92-adc5ad35eb02)


## ❌ 애로 사항

## 📚 Reference

