### PR TITLE
[fix] 코스 독립적으로 방문체크하는 로직 수정

### DIFF
--- a/src/main/java/umc/catchy/domain/mapping/placeVisit/dao/PlaceVisitRepository.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeVisit/dao/PlaceVisitRepository.java
@@ -16,8 +16,12 @@ import java.util.Optional;
 @Repository
 public interface PlaceVisitRepository extends JpaRepository<PlaceVisit, Long> {
     Optional<PlaceVisit> findByPlaceAndMember(Place place, Member member);
+    Optional<PlaceVisit> findByPlaceAndMemberAndCourse(Place place, Member member, Course course);
+
     Optional<PlaceVisit> findByPlaceIdAndMemberId(Long placeId, Long memberId);
     Optional<PlaceVisit> findByPlaceAndMemberAndVisitedDate(Place place, Member member, LocalDate visitedDate);
+    Optional<PlaceVisit> findByPlaceAndMemberAndCourseAndVisitedDate(Place place, Member member, Course course, LocalDate visitedDate);
+
 
     @Query("SELECT pv FROM PlaceVisit pv JOIN FETCH pv.place p WHERE pv.member.id = :memberId AND p.id IN :placeIds")
     List<PlaceVisit> findPlaceVisitsByMemberAndPlaces(@Param("memberId") Long memberId, @Param("placeIds") List<Long> placeIds);

--- a/src/main/java/umc/catchy/domain/mapping/placeVisit/service/PlaceVisitService.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeVisit/service/PlaceVisitService.java
@@ -54,7 +54,7 @@ public class PlaceVisitService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.COURSE_INVALID_MEMBER));
 
         // 이미 오늘 방문 체크를 하였다면 예외 처리
-        Optional<PlaceVisit> optionalPlaceVisit = placeVisitRepository.findByPlaceAndMemberAndVisitedDate(place, member, LocalDate.now());
+        Optional<PlaceVisit> optionalPlaceVisit = placeVisitRepository.findByPlaceAndMemberAndCourseAndVisitedDate(place, member, course, LocalDate.now());
         if (optionalPlaceVisit.isPresent()) {
             throw new GeneralException(ErrorStatus.PLACE_VISIT_ALREADY_CHECK);
         }
@@ -69,11 +69,11 @@ public class PlaceVisitService {
         int placeNum = placeCourses.size();
         int visitNum = (int) placeCourses.stream()
                 .filter(placeCourse -> {
-                    Optional<PlaceVisit> optionalVisit = placeVisitRepository.findByPlaceAndMember(placeCourse.getPlace(), member);
+                    Optional<PlaceVisit> optionalVisit = placeVisitRepository.findByPlaceAndMemberAndCourse(placeCourse.getPlace(), member, course);
                     return optionalVisit.isPresent();
                 }).count();
 
-        if (visitNum > placeNum / 2) {
+        if (visitNum == Math.round((double) placeNum / 2)) {
             memberCourse.setVisited(true);
             memberCourse.setVisitedDate(LocalDate.now());
             course.setParticipantsNumber(course.getParticipantsNumber() + 1);


### PR DESCRIPTION
## 📌 Issue Number

- close #219 

## 🪐 작업 내용

- 방문체크 로직에 오류가 있어 수정했어요

## ✅ PR 상세 내용

- 코스 방문 카운트 정상적으로 오르게 수정
- 다른 코스에 같은 장소를 방문 체크할 때, 예외 처리하던 부분을 수정
