### PR TITLE
[fix] OSRM Route 요청 url에 geometry 옵션 추가

### DIFF
--- a/src/main/java/umc/catchy/infra/osrm/OsrmRequest.java
+++ b/src/main/java/umc/catchy/infra/osrm/OsrmRequest.java
@@ -34,7 +34,7 @@ public class OsrmRequest {
         @NotNull(message = "Start location is required")
         routeInfo start;
 
-        @Size(max = 6, message = "Routes can contain up to 8 waypoints")
+        @Size(max = 3, message = "Routes can contain up to 5 waypoints")
         List<routeInfo> routes;
 
         @NotNull(message = "End location is required")

--- a/src/main/java/umc/catchy/infra/osrm/OsrmResponse.java
+++ b/src/main/java/umc/catchy/infra/osrm/OsrmResponse.java
@@ -18,36 +18,44 @@ public class OsrmResponse {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class Route {
-        private String geometry;
+        private Geometry geometry;
         private List<Leg> legs;
-        private double weight;
-        private double duration;
         private double distance;
+        private double duration;
         private String weight_name;
+        private double weight;
+
+        @Data
+        @AllArgsConstructor
+        @NoArgsConstructor
+        public static class Geometry{
+            private List<List<Double>> coordinates;
+            private String type;
+        }
 
         @Data
         @AllArgsConstructor
         @NoArgsConstructor
         public static class Leg {
             private List<Step> steps;
+            private double distance;
+            private double duration;
             private String summary;
             private double weight;
-            private double duration;
-            private double distance;
 
             @Data
             @AllArgsConstructor
             @NoArgsConstructor
             public static class Step {
-                private String geometry;
-                private Maneuver maneuver;
-                private String mode;
-                private String driving_side;
-                private String name;
                 private List<Intersection> intersections;
-                private double weight;
+                private String driving_side;
+                private Geometry geometry;
+                private String mode;
                 private double duration;
+                private Maneuver maneuver;
+                private double weight;
                 private double distance;
+                private String name;
 
                 @Data
                 @AllArgsConstructor
@@ -63,21 +71,20 @@ public class OsrmResponse {
                 @Data
                 @AllArgsConstructor
                 @NoArgsConstructor
+                public static class Geometry{
+                    private List<List<Double>> coordinates;
+                    private String type;
+                }
+
+                @Data
+                @AllArgsConstructor
+                @NoArgsConstructor
                 public static class Intersection {
                     private int out;
                     private int in;
                     private List<Boolean> entry;
                     private List<Integer> bearings;
                     private List<Double> location;
-                    private List<Lane> lanes;
-
-                    @Data
-                    @AllArgsConstructor
-                    @NoArgsConstructor
-                    public static class Lane {
-                        private boolean valid;
-                        private List<String> indications;
-                    }
                 }
             }
         }

--- a/src/main/java/umc/catchy/infra/osrm/OsrmService.java
+++ b/src/main/java/umc/catchy/infra/osrm/OsrmService.java
@@ -9,6 +9,8 @@ public class OsrmService {
 
     @Value("${osrm.base-url}")
     private String osrmBaseUrl;
+    @Value("${osrm.param}")
+    private String osrmOption;
     private final RestTemplate restTemplate;
 
     public OsrmService(){
@@ -25,7 +27,7 @@ public class OsrmService {
             String routeUrl = route.getLongitude() + "," + route.getLatitude() + ";";
             osrmUrl.append(routeUrl);
         }
-        osrmUrl.append(end).append("?steps=true");
+        osrmUrl.append(end).append(osrmOption);
         return restTemplate.getForObject(osrmUrl.toString(), OsrmResponse.class);
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -73,6 +73,7 @@ openai:
 
 osrm:
   base-url: ${OSRM_BASE_URL}
+  param: ${OSRM_OPTION}
 
 cache:
   recommended-courses:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -73,6 +73,7 @@ openai:
 
 osrm:
   base-url: ${OSRM_BASE_URL}
+  param: ${OSRM_OPTION}
 
 cache:
   recommended-courses:


### PR DESCRIPTION
## 📌 Issue Number

- close #226 

## 🪐 작업 내용

- REST 요청 url의 파라미터 변경

## ✅ PR 상세 내용

- 요청 url의 파라미터도 환경변수로 처리하도록 수정
- 파라미터 변경에 따른 OSRM response 전달 구조 변경

## 📸 스크린샷(선택)
-request
{
  "start": {
    "longitude": 127.04043324,
    "latitude": 37.52432132
  },
  "routes": [
    {
      "longitude": 127.04682156,
      "latitude": 37.52382150
    }
  ],
  "end": {
    "longitude": 127.04951576,
    "latitude": 37.52396042
  }
}
-response
![image](https://github.com/user-attachments/assets/179762a3-c7e6-40dd-8dbb-56eb5fbb31fb)

## ❌ 애로 사항

## 📚 Reference
