### PR TITLE
[chore] 캐시 적용을 통한 빌드 시간 단축

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -41,7 +41,7 @@ jobs:
         run: ./gradlew bootJar
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: app-jar
           path: build/libs/*.jar
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download JAR Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: app-jar
           path: build/libs/

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -40,54 +40,14 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew bootJar
 
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: app-jar
-          path: build/libs/*.jar
-          retention-days: 1
-
-  docker:
-    needs: build
-    name: Docker Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Download JAR Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: app-jar
-          path: build/libs/
-
-      - name : Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}:latest
-          platforms: linux/amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Clean up Artifact
-        run: rm -rf build/libs/*.jar
+      - name: Docker build and push
+        run: |
+          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+          docker build --platform linux/amd64 -t ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }} .
+          docker push ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
 
   deploy:
-    needs: docker
+    needs: build
     name: Deploy
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -39,7 +39,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Build with Gradle
-        run: ./gradlew assemble
+        run: ./gradlew bootJar
 
       - name: Docker build and push
         run: |

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -38,7 +38,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Build with Gradle
-        run: ./gradlew bootJar
+        run: ./gradlew bootJar --no-daemon
 
       - name: Docker build and push
         run: |

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -13,9 +13,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # 빌드 시간 향상을 위한 gradle caching
       - name: Gradle Caching
@@ -41,14 +40,53 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew bootJar
 
-      - name: Docker build and push
-        run: |
-          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
-          docker build --platform linux/amd64 -t ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }} .
-          docker push ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: app-jar
+          path: build/libs/*.jar
+
+  docker:
+    needs: build
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Download JAR Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: app-jar
+          path: build/libs/
+
+      - name : Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}:latest
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Clean up Artifact
+        run: rm -rf build/libs/*.jar
 
   deploy:
-    needs: build
+    needs: docker
     name: Deploy
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -16,17 +16,30 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      # 빌드 시간 향상을 위한 gradle caching
+      - name: Gradle Caching
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: "${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}"
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
+          cache: 'gradle'
 
       - name: Grant permission
         run: chmod +x ./gradlew
 
       - name: Build with Gradle
-        run: ./gradlew bootJar
+        run: ./gradlew assemble
 
       - name: Docker build and push
         run: |

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           name: app-jar
           path: build/libs/*.jar
+          retention-days: 1
 
   docker:
     needs: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,16 @@
 # 1단계 : 빌드 환경
 FROM eclipse-temurin:17-jdk-alpine AS builder
-
 # 작업 디렉토리 설정
 WORKDIR /app
-
 # 애플리케이션 JAR 파일을 컨테이너로 복사
 ARG JAR_FILE=./build/libs/*.jar
 COPY ${JAR_FILE} /app.jar
 
 # 2단계 : 실행 환경
 FROM eclipse-temurin:17-jre-alpine
-
 # glibc 호환성을 위한 gcompat 설치
 RUN apk add --no-cache gcompat
-
 # 빌드된 JAR 파일을 복사
 COPY --from=builder /app.jar /app.jar
-
-# Spring 프로파일 설정
-ENV SPRING_PROFILES_ACTIVE=prod
-
 # 애플리케이션 실행
-ENTRYPOINT ["java", "-Dspring.profiles.active=${SPRING_PROFILES_ACTIVE}", "-jar", "/app.jar"]
+ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-jar", "/app.jar"]


### PR DESCRIPTION
## 📌 Issue Number

- close #220 

## 🪐 작업 내용

- CI/CD 배포에 소모되는 시간을 줄이고자 캐싱 적용

> 기존 빌드 시 소요되던 시간 / GHA runner에 성능에 따른 편차가 존재함
gradle 빌드 : 약 48s ~ 1m 10s
docker 빌드 : 약 12s ~ 17s

## ✅ PR 상세 내용

- Gradle 빌드에 캐시 적용 (actions/cache, JDK-setup : cache 옵션)
- gradle --no-daemon 옵션 적용
- 도커 이미지 빌드에 캐시 적용 (docker/build-push-action)
- 빌드 속도 테스트

## 📸 스크린샷(선택)
- 캐시 생성
![image](https://github.com/user-attachments/assets/e1aacdb5-18fe-4335-ac79-f07e977d979e)

- 성능 테스트 (빌드 시간/워크플로우 시간)
[직전 워크 플로우] : 1m 15s / 2m 5s (https://github.com/Catch-y/Spring_BE/actions/runs/13412291053)
[전전 워크플로우] : 1m 36s / 2m 19s (https://github.com/Catch-y/Spring_BE/actions/runs/13408968902)
1. gradle 캐시
[캐시 적용 후-1] 45s / 1m 30s (https://github.com/Catch-y/Spring_BE/actions/runs/13413539952)
[캐시 적용 후-2] 46s / 1m 29s (https://github.com/Catch-y/Spring_BE/actions/runs/13415569299/attempts/1)
[캐시 삭제 후 실행] 56s / 1m 44s (https://github.com/Catch-y/Spring_BE/actions/runs/13415569299/attempts/3)
2. 도커 캐시
[캐시 적용 후-1] 35s + 52s / 2m 31s (https://github.com/Catch-y/Spring_BE/actions/runs/13414459309)
[캐시 적용 후-2] 36s + 1m 26s / 2m 59s (https://github.com/Catch-y/Spring_BE/actions/runs/13414730011)

- 결론 : runner의 속도가 보장되지 않는 gha의 특성 상, 편차가 있는 편이지만, gradle 캐시 적용, 도커 캐시 미적용이 빌드 시간에 있어 가장 최적화된 것으로 보임.

## ❌ 애로 사항
- ./greadlew assemble로 빌드 시 실행 가능한 JAR을 만들지 않음 
-> 빌드 시간은 빨라 테스트 빌드에는 적합하지만, 도커 이미지 등을 만드는 경우에는 적합하지 않음.

=>빌드 명령어를 다시 bootJar로 바꿔 해결함.

- actions/upload-artifact 및 actions/download-artifact v3가 2025/01/30 이후로 서비스 종료 됨 => v4로 마이그레이션
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

## 📚 Reference
- https://github.com/actions/cache/blob/main/examples.md#java---gradle
- https://github.com/docker/build-push-action/tree/master
- https://fe-developers.kakaoent.com/2022/220414-docker-cache/