### PR TITLE
[fix] BigCategory enum 값 수정

### DIFF
--- a/src/main/java/umc/catchy/domain/category/domain/BigCategory.java
+++ b/src/main/java/umc/catchy/domain/category/domain/BigCategory.java
@@ -13,9 +13,9 @@ public enum BigCategory {
     BAR("주류"),
     RESTAURANT("음식점"),
     EXPERIENCE("체험"),
-    CULTURE("문화생활"),
-    SPORTS("스포츠"),
-    WELLNESS("휴식/웰니스");
+    CULTURELIFE("문화생활"),
+    SPORT("스포츠"),
+    REST("휴식");
 
     private final String value;
 


### PR DESCRIPTION
## 📌 Issue Number

- close #236 

## 🪐 작업 내용

- BigCategory enum 값 수정

## ✅ PR 상세 내용

CAFE = "카페"
BAR = "주류"
RESTAURANT = "음식점"
EXPERIENCE = "체험"
CULTURELIFE = "문화생활"
SPORT = "스포츠"
REST = "휴식"
