### PR TITLE
[refactor] MemberCourse 도메인 리팩토링

### DIFF
--- a/src/main/java/umc/catchy/domain/course/api/CourseController.java
+++ b/src/main/java/umc/catchy/domain/course/api/CourseController.java
@@ -9,7 +9,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
-import umc.catchy.domain.course.domain.CourseType;
 import umc.catchy.domain.course.dto.request.CourseCreateRequest;
 import umc.catchy.domain.course.dto.request.CourseUpdateRequest;
 import umc.catchy.domain.course.dto.response.CourseDetailResponse;
@@ -23,8 +22,6 @@ import umc.catchy.domain.course.service.CourseService;
 import umc.catchy.domain.courseReview.dto.request.PostCourseReviewRequest;
 import umc.catchy.domain.courseReview.dto.response.PostCourseReviewResponse;
 import umc.catchy.domain.courseReview.service.CourseReviewService;
-import umc.catchy.domain.mapping.memberCourse.dto.response.CourseBookmarkResponse;
-import umc.catchy.domain.mapping.memberCourse.dto.response.MemberCourseSliceResponse;
 import umc.catchy.domain.mapping.memberCourse.service.MemberCourseService;
 import umc.catchy.domain.mapping.placeVisit.dto.response.PlaceVisitedResponse;
 import umc.catchy.domain.mapping.placeVisit.service.PlaceVisitService;
@@ -50,7 +47,6 @@ public class CourseController {
     private final AICourseGenerationService aiCourseGenerationService;
     private final CourseRecommendationService courseRecommendationService;
     private final CourseReviewService courseReviewService;
-    private final MemberCourseService memberCourseService;
     private final PlaceService placeService;
     private final PlaceVisitService placeVisitService;
 
@@ -61,19 +57,6 @@ public class CourseController {
             @PathVariable Long courseId
     ){
         CourseDetailResponse response = courseService.getCourseDetails(courseId);
-        return ResponseEntity.ok(BaseResponse.onSuccess(SuccessStatus._OK, response));
-    }
-
-    @Operation(summary = "내 코스 조회 API", description = "코스 탭에서 DIY/AI, 지역별로 사용자의 코스를 최신순으로 조회")
-    @GetMapping("/search")
-    public ResponseEntity<BaseResponse<MemberCourseSliceResponse>> getMemberCourses(
-            @Parameter(description = "AI/DIY 선택", required = true)
-            @RequestParam(value = "type") CourseType type,
-            @RequestParam(value = "upperLocation", defaultValue = "all") String upperLocation,
-            @RequestParam(value = "lowerLocation", defaultValue = "all") String lowerLocation,
-            @RequestParam(required = false) Long lastId
-    ) {
-        MemberCourseSliceResponse response = courseService.getMemberCourses(type, upperLocation, lowerLocation, lastId);
         return ResponseEntity.ok(BaseResponse.onSuccess(SuccessStatus._OK, response));
     }
 
@@ -117,13 +100,6 @@ public class CourseController {
             request.setImages(Collections.emptyList());
         }
         PostCourseReviewResponse.newCourseReviewResponseDTO response = courseReviewService.postNewCourseReview(courseId, request);
-        return ResponseEntity.ok(BaseResponse.onSuccess(SuccessStatus._OK, response));
-    }
-
-    @Operation(summary = "코스 북마크 API", description = "사용자가 해당 코스를 북마크합니다.")
-    @PatchMapping("/{courseId}/bookmark")
-    public ResponseEntity<BaseResponse<CourseBookmarkResponse>> toggleBookmark(@PathVariable Long courseId) {
-        CourseBookmarkResponse response = memberCourseService.toggleBookmark(courseId);
         return ResponseEntity.ok(BaseResponse.onSuccess(SuccessStatus._OK, response));
     }
 

--- a/src/main/java/umc/catchy/domain/course/service/CourseService.java
+++ b/src/main/java/umc/catchy/domain/course/service/CourseService.java
@@ -13,8 +13,6 @@ import umc.catchy.domain.course.dto.response.GptPlaceInfoResponse;
 import umc.catchy.domain.courseReview.dao.CourseReviewRepository;
 import umc.catchy.domain.mapping.memberCourse.dao.MemberCourseRepository;
 import umc.catchy.domain.mapping.memberCourse.domain.MemberCourse;
-import umc.catchy.domain.mapping.memberCourse.dto.response.MemberCourseResponse;
-import umc.catchy.domain.mapping.memberCourse.dto.response.MemberCourseSliceResponse;
 import umc.catchy.domain.mapping.placeCourse.dao.PlaceCourseRepository;
 import umc.catchy.domain.mapping.placeCourse.domain.PlaceCourse;
 import umc.catchy.domain.mapping.placeVisit.dao.PlaceVisitRepository;
@@ -34,8 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
-
-import org.springframework.data.domain.Slice;
 
 @Service
 @RequiredArgsConstructor
@@ -74,17 +70,6 @@ public class CourseService {
                 getBookmarks(course, member),
                 placeListOfCourse
         );
-    }
-
-    public MemberCourseSliceResponse getMemberCourses(CourseType courseType, String upperLocation,
-                                                      String lowerLocation, Long lastId) {
-        Member member = getCurrentMember();
-
-        Slice<MemberCourseResponse> responses = memberCourseRepository.findCourseByFilters(
-                courseType, upperLocation, lowerLocation, member.getId(), lastId
-        );
-
-        return MemberCourseSliceResponse.from(responses);
     }
 
     @Transactional

--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/api/MemberCourseController.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/api/MemberCourseController.java
@@ -1,13 +1,12 @@
 package umc.catchy.domain.mapping.memberCourse.api;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-import umc.catchy.domain.mapping.memberCourse.dto.response.MemberCourseResponse;
+import org.springframework.web.bind.annotation.*;
+import umc.catchy.domain.course.domain.CourseType;
+import umc.catchy.domain.mapping.memberCourse.dto.response.CourseBookmarkResponse;
 import umc.catchy.domain.mapping.memberCourse.dto.response.MemberCourseSliceResponse;
 import umc.catchy.domain.mapping.memberCourse.service.MemberCourseService;
 import umc.catchy.global.common.response.BaseResponse;
@@ -17,6 +16,26 @@ import umc.catchy.global.common.response.status.SuccessStatus;
 @RequiredArgsConstructor
 public class MemberCourseController {
     private final MemberCourseService memberCourseService;
+
+    @Operation(summary = "내 코스 조회 API", description = "코스 탭에서 DIY/AI, 지역별로 사용자의 코스를 최신순으로 조회")
+    @GetMapping("/course/search")
+    public ResponseEntity<BaseResponse<MemberCourseSliceResponse>> getMemberCourses(
+            @Parameter(description = "AI/DIY 선택", required = true)
+            @RequestParam(value = "type") CourseType type,
+            @RequestParam(value = "upperLocation", defaultValue = "all") String upperLocation,
+            @RequestParam(value = "lowerLocation", defaultValue = "all") String lowerLocation,
+            @RequestParam(required = false) Long lastId
+    ) {
+        MemberCourseSliceResponse response = memberCourseService.getMemberCourses(type, upperLocation, lowerLocation, lastId);
+        return ResponseEntity.ok(BaseResponse.onSuccess(SuccessStatus._OK, response));
+    }
+
+    @Operation(summary = "코스 북마크 API", description = "사용자가 해당 코스를 북마크합니다.")
+    @PatchMapping("/course/{courseId}/bookmark")
+    public ResponseEntity<BaseResponse<CourseBookmarkResponse>> toggleBookmark(@PathVariable Long courseId) {
+        CourseBookmarkResponse response = memberCourseService.toggleBookmark(courseId);
+        return ResponseEntity.ok(BaseResponse.onSuccess(SuccessStatus._OK, response));
+    }
 
     @Operation(summary = "북마크된 코스 무한 스크롤 API", description = "북마크된 코스 정보들을 무한 스크롤로 보여줍니다.")
     @GetMapping("/mypage/bookmark")

--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/dao/MemberCourseRepositoryImpl.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/dao/MemberCourseRepositoryImpl.java
@@ -28,6 +28,11 @@ import static umc.catchy.domain.place.domain.QPlace.place;
 public class MemberCourseRepositoryImpl implements MemberCourseRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
+    private static final String ALL_LOCATION = "all";
+    private static final String SPACE = " ";
+    private static final int FILTER_PAGE_SIZE = 10;
+    private static final int FILTER_FETCH_SIZE = FILTER_PAGE_SIZE + 1;
+
     @Override
     public Slice<MemberCourseResponse> findCourseByBookmarks(Long memberId, int pageSize, Long lastCourseId) {
 
@@ -78,12 +83,12 @@ public class MemberCourseRepositoryImpl implements MemberCourseRepositoryCustom 
                 )
                 .groupBy(memberCourse.id)
                 .orderBy(course.createdDate.desc())
-                .limit(11)
+                .limit(FILTER_FETCH_SIZE)
                 .fetch();
 
         List<MemberCourseResponse> results = fetchCategoriesAndBuildResponses(dtos);
 
-        return checkLastPage(10, results);
+        return checkLastPage(FILTER_PAGE_SIZE, results);
     }
 
     private List<MemberCourseResponse> fetchCategoriesAndBuildResponses(List<MemberCourseDto> dtos) {
@@ -91,10 +96,12 @@ public class MemberCourseRepositoryImpl implements MemberCourseRepositoryCustom 
             return List.of();
         }
 
+        // 1. 모든 courseId 추출
         List<Long> courseIds = dtos.stream()
                 .map(MemberCourseDto::courseId)
                 .toList();
 
+        // 2. IN 쿼리로 한 번에 조회
         List<Tuple> categoryTuples = queryFactory
                 .select(
                         placeCourse.course.id,
@@ -106,6 +113,7 @@ public class MemberCourseRepositoryImpl implements MemberCourseRepositoryCustom 
                 .where(placeCourse.course.id.in(courseIds))
                 .fetch();
 
+        // 3. Map으로 그룹핑
         Map<Long, List<BigCategory>> categoryMap = categoryTuples.stream()
                 .collect(Collectors.groupingBy(
                         tuple -> tuple.get(placeCourse.course.id),
@@ -115,6 +123,7 @@ public class MemberCourseRepositoryImpl implements MemberCourseRepositoryCustom 
                         )
                 ));
 
+        // 4. 결과 조합
         List<MemberCourseResponse> results = new ArrayList<>();
         for (MemberCourseDto dto : dtos) {
             List<BigCategory> categories = categoryMap.getOrDefault(dto.courseId(), List.of());
@@ -129,7 +138,7 @@ public class MemberCourseRepositoryImpl implements MemberCourseRepositoryCustom 
         return results;
     }
 
-    private BooleanExpression markedCondition = memberCourse.bookmark.eq(true);
+    private final BooleanExpression markedCondition = memberCourse.bookmark.eq(true);
 
     private BooleanExpression lastCourseId(Long courseId) {
         if (courseId == null) {
@@ -150,16 +159,16 @@ public class MemberCourseRepositoryImpl implements MemberCourseRepositoryCustom 
     }
 
     private BooleanExpression upperLocationFilter(String upperLocation) {
-        if ("all".equals(upperLocation)) {
+        if (ALL_LOCATION.equals(upperLocation)) {
             return null;
         }
-        return place.roadAddress.startsWith(LocationUtils.normalizeLocation(upperLocation) + " ");
+        return place.roadAddress.startsWith(LocationUtils.normalizeLocation(upperLocation) + SPACE);
     }
 
     private BooleanExpression lowerLocationFilter(String lowerLocation) {
-        if ("all".equals(lowerLocation)) {
+        if (ALL_LOCATION.equals(lowerLocation)) {
             return null;
         }
-        return place.roadAddress.contains(" " + lowerLocation);
+        return place.roadAddress.contains(SPACE + lowerLocation);
     }
 }

--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/dao/MemberCourseRepositoryImpl.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/dao/MemberCourseRepositoryImpl.java
@@ -1,5 +1,6 @@
 package umc.catchy.domain.mapping.memberCourse.dao;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -7,23 +8,21 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
-
 import umc.catchy.domain.category.domain.BigCategory;
 import umc.catchy.domain.course.domain.CourseType;
 import umc.catchy.domain.course.util.LocationUtils;
 import umc.catchy.domain.mapping.memberCourse.dto.response.MemberCourseDto;
 import umc.catchy.domain.mapping.memberCourse.dto.response.MemberCourseResponse;
 
+import java.util.*;
+import java.util.stream.Collectors;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-
+import static umc.catchy.domain.category.domain.QCategory.category;
 import static umc.catchy.domain.course.domain.QCourse.course;
-import static umc.catchy.domain.mapping.memberCourse.domain.QMemberCourse.*;
-import static umc.catchy.domain.mapping.placeCourse.domain.QPlaceCourse.*;
-import static umc.catchy.domain.member.domain.QMember.*;
-import static umc.catchy.domain.place.domain.QPlace.*;
+import static umc.catchy.domain.mapping.memberCourse.domain.QMemberCourse.memberCourse;
+import static umc.catchy.domain.mapping.placeCourse.domain.QPlaceCourse.placeCourse;
+import static umc.catchy.domain.member.domain.QMember.member;
+import static umc.catchy.domain.place.domain.QPlace.place;
 
 @RequiredArgsConstructor
 public class MemberCourseRepositoryImpl implements MemberCourseRepositoryCustom {
@@ -50,19 +49,7 @@ public class MemberCourseRepositoryImpl implements MemberCourseRepositoryCustom 
                 .limit(pageSize + 1)
                 .fetch();
 
-        List<MemberCourseResponse> results = new ArrayList<>();
-        for (MemberCourseDto dto : dtos) {
-            List<BigCategory> bigCategoriesDuplicates = queryFactory.select(placeCourse.place.category.bigCategory)
-                    .from(placeCourse)
-                    .innerJoin(placeCourse.place, place).on(placeCourse.place.id.eq(place.id))
-                    .innerJoin(placeCourse.course, course).on(placeCourse.course.id.eq(course.id))
-                    .where(placeCourse.course.id.eq(dto.courseId()))
-                    .fetch();
-            List<BigCategory> bigCategories = new ArrayList<>(new HashSet<>(bigCategoriesDuplicates));
-            List<String> bigCategoryStrings = bigCategories.stream().map(BigCategory::getValue).toList();
-
-            results.add(dto.toResponse(bigCategoryStrings));
-        }
+        List<MemberCourseResponse> results = fetchCategoriesAndBuildResponses(dtos);
 
         return checkLastPage(pageSize, results);
     }
@@ -94,21 +81,52 @@ public class MemberCourseRepositoryImpl implements MemberCourseRepositoryCustom 
                 .limit(11)
                 .fetch();
 
-        List<MemberCourseResponse> results = new ArrayList<>();
-        for (MemberCourseDto dto : dtos) {
-            List<BigCategory> bigCategoriesDuplicates = queryFactory.select(placeCourse.place.category.bigCategory)
-                    .from(placeCourse)
-                    .innerJoin(placeCourse.place, place).on(placeCourse.place.id.eq(place.id))
-                    .innerJoin(placeCourse.course, course).on(placeCourse.course.id.eq(course.id))
-                    .where(placeCourse.course.id.eq(dto.courseId()))
-                    .fetch();
-            List<BigCategory> bigCategories = new ArrayList<>(new HashSet<>(bigCategoriesDuplicates));
-            List<String> bigCategoryStrings = bigCategories.stream().map(BigCategory::getValue).toList();
-
-            results.add(dto.toResponse(bigCategoryStrings));
-        }
+        List<MemberCourseResponse> results = fetchCategoriesAndBuildResponses(dtos);
 
         return checkLastPage(10, results);
+    }
+
+    private List<MemberCourseResponse> fetchCategoriesAndBuildResponses(List<MemberCourseDto> dtos) {
+        if (dtos.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> courseIds = dtos.stream()
+                .map(MemberCourseDto::courseId)
+                .toList();
+
+        List<Tuple> categoryTuples = queryFactory
+                .select(
+                        placeCourse.course.id,
+                        placeCourse.place.category.bigCategory
+                )
+                .from(placeCourse)
+                .innerJoin(placeCourse.place, place)
+                .innerJoin(place.category, category)
+                .where(placeCourse.course.id.in(courseIds))
+                .fetch();
+
+        Map<Long, List<BigCategory>> categoryMap = categoryTuples.stream()
+                .collect(Collectors.groupingBy(
+                        tuple -> tuple.get(placeCourse.course.id),
+                        Collectors.mapping(
+                                tuple -> tuple.get(placeCourse.place.category.bigCategory),
+                                Collectors.toList()
+                        )
+                ));
+
+        List<MemberCourseResponse> results = new ArrayList<>();
+        for (MemberCourseDto dto : dtos) {
+            List<BigCategory> categories = categoryMap.getOrDefault(dto.courseId(), List.of());
+            List<BigCategory> uniqueCategories = new ArrayList<>(new HashSet<>(categories));
+            List<String> categoryStrings = uniqueCategories.stream()
+                    .map(BigCategory::getValue)
+                    .toList();
+
+            results.add(dto.toResponse(categoryStrings));
+        }
+
+        return results;
     }
 
     private BooleanExpression markedCondition = memberCourse.bookmark.eq(true);
@@ -128,7 +146,7 @@ public class MemberCourseRepositoryImpl implements MemberCourseRepositoryCustom 
             results.remove(pageSize);
         }
 
-        return new SliceImpl<>(results, PageRequest.of(0,pageSize), hasNext);
+        return new SliceImpl<>(results, PageRequest.of(0, pageSize), hasNext);
     }
 
     private BooleanExpression upperLocationFilter(String upperLocation) {
@@ -144,5 +162,4 @@ public class MemberCourseRepositoryImpl implements MemberCourseRepositoryCustom 
         }
         return place.roadAddress.contains(" " + lowerLocation);
     }
-
 }

--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/dao/MemberCourseRepositoryImpl.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/dao/MemberCourseRepositoryImpl.java
@@ -11,13 +11,13 @@ import org.springframework.data.domain.SliceImpl;
 import umc.catchy.domain.category.domain.BigCategory;
 import umc.catchy.domain.course.domain.CourseType;
 import umc.catchy.domain.course.util.LocationUtils;
+import umc.catchy.domain.mapping.memberCourse.dto.response.MemberCourseDto;
 import umc.catchy.domain.mapping.memberCourse.dto.response.MemberCourseResponse;
 
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import umc.catchy.domain.place.domain.QPlace;
 
 import static umc.catchy.domain.course.domain.QCourse.course;
 import static umc.catchy.domain.mapping.memberCourse.domain.QMemberCourse.*;
@@ -32,44 +32,46 @@ public class MemberCourseRepositoryImpl implements MemberCourseRepositoryCustom 
     @Override
     public Slice<MemberCourseResponse> findCourseByBookmarks(Long memberId, int pageSize, Long lastCourseId) {
 
-        List<MemberCourseResponse> results = queryFactory.select(Projections.constructor(MemberCourseResponse.class,
-                course.id,
-                course.courseType,
-                course.courseImage,
-                course.courseName,
-                course.courseDescription))
+        List<MemberCourseDto> dtos = queryFactory.select(Projections.constructor(MemberCourseDto.class,
+                        course.id,
+                        course.courseType,
+                        course.courseImage,
+                        course.courseName,
+                        course.courseDescription))
                 .from(memberCourse)
-                .leftJoin(memberCourse.course,course).on(memberCourse.course.id.eq(course.id))
-                .leftJoin(memberCourse.member,member).on(memberCourse.member.id.eq(member.id))
+                .leftJoin(memberCourse.course, course).on(memberCourse.course.id.eq(course.id))
+                .leftJoin(memberCourse.member, member).on(memberCourse.member.id.eq(member.id))
                 .where(
                         memberCourse.member.id.eq(memberId),
                         lastCourseId(lastCourseId),
                         markedCondition
                 )
                 .orderBy(course.createdDate.desc())
-                .limit(pageSize+1)
+                .limit(pageSize + 1)
                 .fetch();
 
-        for (MemberCourseResponse result : results) {
+        List<MemberCourseResponse> results = new ArrayList<>();
+        for (MemberCourseDto dto : dtos) {
             List<BigCategory> bigCategoriesDuplicates = queryFactory.select(placeCourse.place.category.bigCategory)
                     .from(placeCourse)
-                    .innerJoin(placeCourse.place,place).on(placeCourse.place.id.eq(place.id))
-                    .innerJoin(placeCourse.course,course).on(placeCourse.course.id.eq(course.id))
-                    .where(placeCourse.course.id.eq(result.getCourseId()))
+                    .innerJoin(placeCourse.place, place).on(placeCourse.place.id.eq(place.id))
+                    .innerJoin(placeCourse.course, course).on(placeCourse.course.id.eq(course.id))
+                    .where(placeCourse.course.id.eq(dto.courseId()))
                     .fetch();
             List<BigCategory> bigCategories = new ArrayList<>(new HashSet<>(bigCategoriesDuplicates));
             List<String> bigCategoryStrings = bigCategories.stream().map(BigCategory::getValue).toList();
-            result.setCategories(bigCategoryStrings);
+
+            results.add(dto.toResponse(bigCategoryStrings));
         }
 
-        return checkLastPage(pageSize,results);
+        return checkLastPage(pageSize, results);
     }
 
     @Override
     public Slice<MemberCourseResponse> findCourseByFilters(CourseType courseType, String upperLocation,
                                                            String lowerLocation, Long memberId, Long lastCourseId) {
-        List<MemberCourseResponse> results = queryFactory
-                .select(Projections.constructor(MemberCourseResponse.class,
+        List<MemberCourseDto> dtos = queryFactory
+                .select(Projections.constructor(MemberCourseDto.class,
                         course.id,
                         course.courseType,
                         course.courseImage,
@@ -92,16 +94,18 @@ public class MemberCourseRepositoryImpl implements MemberCourseRepositoryCustom 
                 .limit(11)
                 .fetch();
 
-        for (MemberCourseResponse result : results) {
+        List<MemberCourseResponse> results = new ArrayList<>();
+        for (MemberCourseDto dto : dtos) {
             List<BigCategory> bigCategoriesDuplicates = queryFactory.select(placeCourse.place.category.bigCategory)
                     .from(placeCourse)
-                    .innerJoin(placeCourse.place,place).on(placeCourse.place.id.eq(place.id))
-                    .innerJoin(placeCourse.course,course).on(placeCourse.course.id.eq(course.id))
-                    .where(placeCourse.course.id.eq(result.getCourseId()))
+                    .innerJoin(placeCourse.place, place).on(placeCourse.place.id.eq(place.id))
+                    .innerJoin(placeCourse.course, course).on(placeCourse.course.id.eq(course.id))
+                    .where(placeCourse.course.id.eq(dto.courseId()))
                     .fetch();
             List<BigCategory> bigCategories = new ArrayList<>(new HashSet<>(bigCategoriesDuplicates));
             List<String> bigCategoryStrings = bigCategories.stream().map(BigCategory::getValue).toList();
-            result.setCategories(bigCategoryStrings);
+
+            results.add(dto.toResponse(bigCategoryStrings));
         }
 
         return checkLastPage(10, results);

--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/domain/MemberCourse.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/domain/MemberCourse.java
@@ -5,13 +5,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import umc.catchy.domain.common.BaseTimeEntity;
 import umc.catchy.domain.course.domain.Course;
 import umc.catchy.domain.member.domain.Member;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "member_course", indexes = {
@@ -28,10 +26,8 @@ public class MemberCourse extends BaseTimeEntity {
     @Column(name = "member_course_id")
     private Long id;
 
-    @Setter
     private boolean isVisited = false;
 
-    @Setter
     private LocalDate visitedDate;
 
     private boolean bookmark = false;
@@ -44,7 +40,12 @@ public class MemberCourse extends BaseTimeEntity {
     @JoinColumn(name = "course_id")
     private Course course;
 
-    public static void toggleBookmark(MemberCourse memberCourse) {
-        memberCourse.bookmark = !memberCourse.bookmark;
+    public void toggleBookmark() {
+        this.bookmark = !this.bookmark;
+    }
+
+    public void markAsVisited(LocalDate visitedDate) {
+        this.isVisited = true;
+        this.visitedDate = visitedDate;
     }
 }

--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/dto/response/CourseBookmarkResponse.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/dto/response/CourseBookmarkResponse.java
@@ -1,12 +1,7 @@
 package umc.catchy.domain.mapping.memberCourse.dto.response;
 
-import lombok.*;
-
-@Getter
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class CourseBookmarkResponse {
-    Long memberCourseId;
-    boolean bookmarked;
+public record CourseBookmarkResponse(
+        Long memberCourseId,
+        boolean bookmarked
+) {
 }

--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/dto/response/MemberCourseDto.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/dto/response/MemberCourseDto.java
@@ -1,0 +1,25 @@
+package umc.catchy.domain.mapping.memberCourse.dto.response;
+
+import umc.catchy.domain.course.domain.CourseType;
+
+import java.util.List;
+
+public record MemberCourseDto(
+        Long courseId,
+        CourseType courseType,
+        String courseImage,
+        String courseName,
+        String courseDescription
+) {
+    public MemberCourseResponse toResponse(List<String> categories) {
+        return new MemberCourseResponse(
+                courseId,
+                courseType,
+                courseImage,
+                courseName,
+                courseDescription,
+                categories
+        );
+    }
+}
+

--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/dto/response/MemberCourseResponse.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/dto/response/MemberCourseResponse.java
@@ -1,33 +1,15 @@
 package umc.catchy.domain.mapping.memberCourse.dto.response;
 
-import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import umc.catchy.domain.course.domain.CourseType;
 
-@Getter
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
-public class MemberCourseResponse {
-    Long courseId;
-    CourseType courseType;
-    String courseImage;
-    String courseName;
-    String courseDescription;
-    List<String> categories;
+import java.util.List;
 
-    public MemberCourseResponse(Long courseId, CourseType courseType, String courseImage, String courseName, String courseDescription) {
-        this.courseId = courseId;
-        this.courseType = courseType;
-        this.courseImage = courseImage;
-        this.courseName = courseName;
-        this.courseDescription = courseDescription;
-    }
-
-    public void setCategories(List<String> categories) {
-        this.categories = categories;
-    }
+public record MemberCourseResponse(
+        Long courseId,
+        CourseType courseType,
+        String courseImage,
+        String courseName,
+        String courseDescription,
+        List<String> categories
+) {
 }

--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/service/MemberCourseService.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/service/MemberCourseService.java
@@ -32,7 +32,7 @@ public class MemberCourseService {
         MemberCourse memberCourse = memberCourseRepository.findByCourseIdAndMemberId(courseId, currentMember.getId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.COURSE_MEMBER_NOT_FOUND));
 
-        MemberCourse.toggleBookmark(memberCourse);
+        memberCourse.toggleBookmark();
 
         return new CourseBookmarkResponse(
                 memberCourse.getId(),

--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/service/MemberCourseService.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/service/MemberCourseService.java
@@ -22,13 +22,11 @@ import umc.catchy.global.util.SecurityUtil;
 @Slf4j
 public class MemberCourseService {
 
-    public final MemberCourseRepository memberCourseRepository;
-    public final MemberRepository memberRepository;
+    private final MemberCourseRepository memberCourseRepository;
+    private final MemberRepository memberRepository;
 
     public CourseBookmarkResponse toggleBookmark(Long courseId) {
-        Long memberId = SecurityUtil.getCurrentMemberId();
-        Member currentMember = memberRepository.findById(memberId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+        Member currentMember = getCurrentMember();
         MemberCourse memberCourse = memberCourseRepository.findByCourseIdAndMemberId(courseId, currentMember.getId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.COURSE_MEMBER_NOT_FOUND));
 
@@ -45,5 +43,11 @@ public class MemberCourseService {
         Long memberId = SecurityUtil.getCurrentMemberId();
         Slice<MemberCourseResponse> courseByBookmarks = memberCourseRepository.findCourseByBookmarks(memberId, pageSize, lastCourseId);
         return MemberCourseSliceResponse.from(courseByBookmarks);
+    }
+
+    private Member getCurrentMember() {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/service/MemberCourseService.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/service/MemberCourseService.java
@@ -12,7 +12,6 @@ import umc.catchy.domain.mapping.memberCourse.dto.response.MemberCourseResponse;
 import umc.catchy.domain.mapping.memberCourse.dto.response.MemberCourseSliceResponse;
 import umc.catchy.domain.member.dao.MemberRepository;
 import umc.catchy.domain.member.domain.Member;
-import umc.catchy.global.common.response.code.BaseErrorCode;
 import umc.catchy.global.common.response.status.ErrorStatus;
 import umc.catchy.global.error.exception.GeneralException;
 import umc.catchy.global.util.SecurityUtil;
@@ -22,18 +21,23 @@ import umc.catchy.global.util.SecurityUtil;
 @Transactional
 @Slf4j
 public class MemberCourseService {
+
     public final MemberCourseRepository memberCourseRepository;
     public final MemberRepository memberRepository;
 
     public CourseBookmarkResponse toggleBookmark(Long courseId) {
         Long memberId = SecurityUtil.getCurrentMemberId();
-        Member currentMember = memberRepository.findById(memberId).orElseThrow(() ->new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
-        MemberCourse memberCourse = memberCourseRepository.findByCourseIdAndMemberId(courseId, currentMember.getId()).orElseThrow(() -> new GeneralException(ErrorStatus.COURSE_MEMBER_NOT_FOUND));
+        Member currentMember = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+        MemberCourse memberCourse = memberCourseRepository.findByCourseIdAndMemberId(courseId, currentMember.getId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.COURSE_MEMBER_NOT_FOUND));
+
         MemberCourse.toggleBookmark(memberCourse);
-        return CourseBookmarkResponse.builder()
-                .memberCourseId(memberCourse.getId())
-                .bookmarked(memberCourse.isBookmark())
-                .build();
+
+        return new CourseBookmarkResponse(
+                memberCourse.getId(),
+                memberCourse.isBookmark()
+        );
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/umc/catchy/domain/mapping/memberCourse/service/MemberCourseService.java
+++ b/src/main/java/umc/catchy/domain/mapping/memberCourse/service/MemberCourseService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.catchy.domain.course.domain.CourseType;
 import umc.catchy.domain.mapping.memberCourse.dao.MemberCourseRepository;
 import umc.catchy.domain.mapping.memberCourse.domain.MemberCourse;
 import umc.catchy.domain.mapping.memberCourse.dto.response.CourseBookmarkResponse;
@@ -43,6 +44,18 @@ public class MemberCourseService {
         Long memberId = SecurityUtil.getCurrentMemberId();
         Slice<MemberCourseResponse> courseByBookmarks = memberCourseRepository.findCourseByBookmarks(memberId, pageSize, lastCourseId);
         return MemberCourseSliceResponse.from(courseByBookmarks);
+    }
+
+    @Transactional(readOnly = true)
+    public MemberCourseSliceResponse getMemberCourses(CourseType courseType, String upperLocation,
+                                                      String lowerLocation, Long lastId) {
+        Member member = getCurrentMember();
+
+        Slice<MemberCourseResponse> responses = memberCourseRepository.findCourseByFilters(
+                courseType, upperLocation, lowerLocation, member.getId(), lastId
+        );
+
+        return MemberCourseSliceResponse.from(responses);
     }
 
     private Member getCurrentMember() {

--- a/src/main/java/umc/catchy/domain/mapping/placeVisit/service/PlaceVisitService.java
+++ b/src/main/java/umc/catchy/domain/mapping/placeVisit/service/PlaceVisitService.java
@@ -81,8 +81,7 @@ public class PlaceVisitService {
                 .count();
 
         if (visitNum == Math.round((double) placeNum / 2)) {
-            memberCourse.setVisited(true);
-            memberCourse.setVisitedDate(LocalDate.now());
+            memberCourse.markAsVisited(LocalDate.now());
             course.increaseParticipants();
         }
 

--- a/src/test/java/umc/catchy/domain/course/api/CourseControllerTest.java
+++ b/src/test/java/umc/catchy/domain/course/api/CourseControllerTest.java
@@ -83,43 +83,6 @@ class CourseControllerTest extends ControllerTestSupport {
     }
 
     @Test
-    @DisplayName("내 코스 조회 API (검색/필터링) - 성공")
-    void getMemberCourses_success() throws Exception {
-        // given
-        MemberCourseResponse content = new MemberCourseResponse(
-                100L,
-                CourseType.DIY,
-                null,
-                "테스트 코스",
-                null,
-                List.of("음식점", "카페")
-        );
-
-        MemberCourseSliceResponse response = new MemberCourseSliceResponse(List.of(content), true);
-
-        // 검색 조건
-        CourseType type = CourseType.DIY;
-        String upperLoc = "서울시";
-        String lowerLoc = "강남구";
-        Long lastId = 10L;
-
-        when(courseService.getMemberCourses(eq(type), eq(upperLoc), eq(lowerLoc), eq(lastId)))
-                .thenReturn(response);
-
-        // when & then
-        mockMvc.perform(get("/course/search")
-                        .header("Authorization", testToken)
-                        .param("type", "DIY")
-                        .param("upperLocation", "서울시")
-                        .param("lowerLocation", "강남구")
-                        .param("lastId", "10"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.isSuccess").value(true))
-                .andExpect(jsonPath("$.result.content[0].courseName").value("테스트 코스"))
-                .andExpect(jsonPath("$.result.isLast").value(true));
-    }
-
-    @Test
     @DisplayName("코스 생성 API - 성공 (Multipart)")
     void createCourse_success() throws Exception {
         // given
@@ -237,28 +200,6 @@ class CourseControllerTest extends ControllerTestSupport {
                     .andExpect(jsonPath("$.code").value("GPT404"))
                     .andExpect(jsonPath("$.message").value("GPT 호출에 실패했습니다."));
         }
-    }
-
-    @Test
-    @DisplayName("코스 북마크 토글 API - 성공 (북마크 해제)")
-    void toggleBookmark_success_unbookmark() throws Exception {
-        // given
-        Long courseId = 1L;
-
-        CourseBookmarkResponse response = new CourseBookmarkResponse(
-                100L,
-                false
-        );
-
-        when(memberCourseService.toggleBookmark(courseId)).thenReturn(response);
-
-        // when & then
-        mockMvc.perform(patch("/course/{courseId}/bookmark", courseId)
-                        .header("Authorization", testToken))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.isSuccess").value(true))
-                .andExpect(jsonPath("$.result.memberCourseId").value(100L))
-                .andExpect(jsonPath("$.result.bookmarked").value(false));
     }
 
     @Test

--- a/src/test/java/umc/catchy/domain/course/api/CourseControllerTest.java
+++ b/src/test/java/umc/catchy/domain/course/api/CourseControllerTest.java
@@ -86,11 +86,14 @@ class CourseControllerTest extends ControllerTestSupport {
     @DisplayName("내 코스 조회 API (검색/필터링) - 성공")
     void getMemberCourses_success() throws Exception {
         // given
-        MemberCourseResponse content = MemberCourseResponse.builder()
-                .courseId(100L)
-                .courseName("테스트 코스")
-                .courseType(CourseType.DIY)
-                .build();
+        MemberCourseResponse content = new MemberCourseResponse(
+                100L,
+                CourseType.DIY,
+                null,
+                "테스트 코스",
+                null,
+                List.of("음식점", "카페")
+        );
 
         MemberCourseSliceResponse response = new MemberCourseSliceResponse(List.of(content), true);
 
@@ -242,10 +245,10 @@ class CourseControllerTest extends ControllerTestSupport {
         // given
         Long courseId = 1L;
 
-        CourseBookmarkResponse response = CourseBookmarkResponse.builder()
-                .memberCourseId(100L)
-                .bookmarked(false)
-                .build();
+        CourseBookmarkResponse response = new CourseBookmarkResponse(
+                100L,
+                false
+        );
 
         when(memberCourseService.toggleBookmark(courseId)).thenReturn(response);
 

--- a/src/test/java/umc/catchy/domain/course/service/CourseServiceTest.java
+++ b/src/test/java/umc/catchy/domain/course/service/CourseServiceTest.java
@@ -163,14 +163,14 @@ class CourseServiceTest {
 
             when(memberRepository.findById(1L)).thenReturn(Optional.of(testMember));
 
-            MemberCourseResponse responseDto = MemberCourseResponse.builder()
-                    .courseId(100L)
-                    .courseName("테스트 코스")
-                    .courseDescription("설명")
-                    .courseType(CourseType.DIY)
-                    .courseImage("image.jpg")
-                    .categories(List.of("CAFE", "REST"))
-                    .build();
+            MemberCourseResponse responseDto = new MemberCourseResponse(
+                    100L,
+                    CourseType.DIY,
+                    null,
+                    "테스트 코스",
+                    "설명",
+                    List.of("음식점", "카페")
+            );
 
             Slice<MemberCourseResponse> slice = new SliceImpl<>(List.of(responseDto));
 
@@ -191,7 +191,7 @@ class CourseServiceTest {
             assertAll(
                     () -> assertThat(result).isNotNull(),
                     () -> assertThat(result.content()).hasSize(1),
-                    () -> assertThat(result.content().get(0).getCourseName()).isEqualTo("테스트 코스"),
+                    () -> assertThat(result.content().get(0).courseName()).isEqualTo("테스트 코스"),
                     () -> assertThat(result.isLast()).isTrue()
             );
 

--- a/src/test/java/umc/catchy/domain/course/service/CourseServiceTest.java
+++ b/src/test/java/umc/catchy/domain/course/service/CourseServiceTest.java
@@ -155,53 +155,6 @@ class CourseServiceTest {
     }
 
     @Test
-    @DisplayName("나의 코스 목록 조회 성공 - 필터링 및 페이징")
-    void getMemberCourses_success() {
-        try (MockedStatic<SecurityUtil> mockedSecurityUtil = mockStatic(SecurityUtil.class)) {
-            // given
-            mockSecurityUtil(mockedSecurityUtil);
-
-            when(memberRepository.findById(1L)).thenReturn(Optional.of(testMember));
-
-            MemberCourseResponse responseDto = new MemberCourseResponse(
-                    100L,
-                    CourseType.DIY,
-                    null,
-                    "테스트 코스",
-                    "설명",
-                    List.of("음식점", "카페")
-            );
-
-            Slice<MemberCourseResponse> slice = new SliceImpl<>(List.of(responseDto));
-
-            // 검색 파라미터
-            CourseType courseType = CourseType.DIY;
-            String upperLoc = "서울시";
-            String lowerLoc = "강남구";
-            Long lastId = 200L;
-
-            when(memberCourseRepository.findCourseByFilters(
-                    eq(courseType), eq(upperLoc), eq(lowerLoc), eq(1L), eq(lastId)
-            )).thenReturn(slice);
-
-            // when
-            MemberCourseSliceResponse result = courseService.getMemberCourses(courseType, upperLoc, lowerLoc, lastId);
-
-            // then
-            assertAll(
-                    () -> assertThat(result).isNotNull(),
-                    () -> assertThat(result.content()).hasSize(1),
-                    () -> assertThat(result.content().get(0).courseName()).isEqualTo("테스트 코스"),
-                    () -> assertThat(result.isLast()).isTrue()
-            );
-
-            verify(memberCourseRepository).findCourseByFilters(
-                    eq(courseType), eq(upperLoc), eq(lowerLoc), eq(1L), eq(lastId)
-            );
-        }
-    }
-
-    @Test
     @DisplayName("AI 코스 저장 및 장소 등록 성공 - 시간 파싱, 평점 계산, 순서 보장")
     void saveCourseAndPlaces_success() {
         // given

--- a/src/test/java/umc/catchy/domain/mapping/memberCourse/api/MemberCourseControllerTest.java
+++ b/src/test/java/umc/catchy/domain/mapping/memberCourse/api/MemberCourseControllerTest.java
@@ -1,0 +1,114 @@
+package umc.catchy.domain.mapping.memberCourse.api;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import umc.catchy.domain.course.domain.CourseType;
+import umc.catchy.domain.mapping.memberCourse.dto.response.CourseBookmarkResponse;
+import umc.catchy.domain.mapping.memberCourse.dto.response.MemberCourseResponse;
+import umc.catchy.domain.mapping.memberCourse.dto.response.MemberCourseSliceResponse;
+import umc.catchy.domain.mapping.memberCourse.service.MemberCourseService;
+import umc.catchy.support.ControllerTestSupport;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemberCourseController.class)
+class MemberCourseControllerTest extends ControllerTestSupport {
+
+    @MockitoBean
+    private MemberCourseService memberCourseService;
+
+    @Test
+    @DisplayName("내 코스 조회 API (검색/필터링) - 성공")
+    void getMemberCourses_success() throws Exception {
+        // given
+        MemberCourseResponse content = new MemberCourseResponse(
+                100L,
+                CourseType.DIY,
+                null,
+                "테스트 코스",
+                null,
+                List.of("음식점", "카페")
+        );
+
+        MemberCourseSliceResponse response = new MemberCourseSliceResponse(List.of(content), true);
+
+        CourseType type = CourseType.DIY;
+        String upperLoc = "서울시";
+        String lowerLoc = "강남구";
+        Long lastId = 10L;
+
+        when(memberCourseService.getMemberCourses(eq(type), eq(upperLoc), eq(lowerLoc), eq(lastId)))
+                .thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/course/search")
+                        .header("Authorization", testToken)
+                        .param("type", "DIY")
+                        .param("upperLocation", "서울시")
+                        .param("lowerLocation", "강남구")
+                        .param("lastId", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.content[0].courseName").value("테스트 코스"))
+                .andExpect(jsonPath("$.result.isLast").value(true));
+    }
+
+    @Test
+    @DisplayName("코스 북마크 토글 API - 성공 (북마크 해제)")
+    void toggleBookmark_success_unbookmark() throws Exception {
+        // given
+        Long courseId = 1L;
+
+        CourseBookmarkResponse response = new CourseBookmarkResponse(
+                100L,
+                false
+        );
+
+        when(memberCourseService.toggleBookmark(courseId)).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(patch("/course/{courseId}/bookmark", courseId)
+                        .header("Authorization", testToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.memberCourseId").value(100L))
+                .andExpect(jsonPath("$.result.bookmarked").value(false));
+    }
+
+    @Test
+    @DisplayName("북마크된 코스 목록 조회 - 성공")
+    void findAllCourseByBookmarked_success() throws Exception {
+        // given
+        MemberCourseResponse content = new MemberCourseResponse(
+                200L,
+                CourseType.AI,
+                "image.jpg",
+                "AI 추천 코스",
+                "AI가 추천한 코스입니다.",
+                List.of("관광지", "음식점")
+        );
+
+        MemberCourseSliceResponse response = new MemberCourseSliceResponse(List.of(content), false);
+
+        when(memberCourseService.findAllCourseByBookmarked(eq(10), eq(null)))
+                .thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/mypage/bookmark")
+                        .header("Authorization", testToken)
+                        .param("pageSize", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.content[0].courseName").value("AI 추천 코스"))
+                .andExpect(jsonPath("$.result.isLast").value(false));
+    }
+}

--- a/src/test/java/umc/catchy/domain/mapping/memberCourse/service/MemberCourseServiceTest.java
+++ b/src/test/java/umc/catchy/domain/mapping/memberCourse/service/MemberCourseServiceTest.java
@@ -1,0 +1,271 @@
+package umc.catchy.domain.mapping.memberCourse.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import umc.catchy.domain.course.domain.Course;
+import umc.catchy.domain.course.domain.CourseType;
+import umc.catchy.domain.mapping.memberCourse.dao.MemberCourseRepository;
+import umc.catchy.domain.mapping.memberCourse.domain.MemberCourse;
+import umc.catchy.domain.mapping.memberCourse.dto.response.CourseBookmarkResponse;
+import umc.catchy.domain.mapping.memberCourse.dto.response.MemberCourseResponse;
+import umc.catchy.domain.mapping.memberCourse.dto.response.MemberCourseSliceResponse;
+import umc.catchy.domain.member.dao.MemberRepository;
+import umc.catchy.domain.member.domain.Member;
+import umc.catchy.global.common.response.status.ErrorStatus;
+import umc.catchy.global.error.exception.GeneralException;
+import umc.catchy.global.util.SecurityUtil;
+import umc.catchy.support.fixture.CourseFixture;
+import umc.catchy.support.fixture.MemberCourseFixture;
+import umc.catchy.support.fixture.MemberFixture;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberCourseServiceTest {
+
+    @InjectMocks
+    private MemberCourseService memberCourseService;
+
+    @Mock
+    private MemberCourseRepository memberCourseRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    private Member testMember;
+    private Course testCourse;
+    private MemberCourse testMemberCourse;
+
+    @BeforeEach
+    void setUp() {
+        testMember = MemberFixture.createTestMember();
+        testCourse = CourseFixture.createTestCourse(testMember);
+        testMemberCourse = MemberCourseFixture.createTestMemberCourse(testMember, testCourse);
+    }
+
+    private void mockSecurityUtil(MockedStatic<SecurityUtil> mockedSecurityUtil) {
+        mockedSecurityUtil.when(SecurityUtil::getCurrentMemberId).thenReturn(1L);
+    }
+
+    @Test
+    @DisplayName("북마크 토글 성공 - 북마크 ON")
+    void toggleBookmark_success_on() {
+        try (MockedStatic<SecurityUtil> mockedSecurityUtil = mockStatic(SecurityUtil.class)) {
+            // given
+            mockSecurityUtil(mockedSecurityUtil);
+
+            when(memberRepository.findById(1L)).thenReturn(Optional.of(testMember));
+            when(memberCourseRepository.findByCourseIdAndMemberId(1L, 1L))
+                    .thenReturn(Optional.of(testMemberCourse));
+
+            // when
+            CourseBookmarkResponse result = memberCourseService.toggleBookmark(1L);
+
+            // then
+            assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result.memberCourseId()).isEqualTo(1L),
+                    () -> assertThat(result.bookmarked()).isTrue()
+            );
+
+            verify(memberRepository).findById(1L);
+            verify(memberCourseRepository).findByCourseIdAndMemberId(1L, 1L);
+        }
+    }
+
+    @Test
+    @DisplayName("북마크 토글 실패 - 존재하지 않는 회원")
+    void toggleBookmark_fail_memberNotFound() {
+        try (MockedStatic<SecurityUtil> mockedSecurityUtil = mockStatic(SecurityUtil.class)) {
+            // given
+            mockSecurityUtil(mockedSecurityUtil);
+
+            when(memberRepository.findById(1L)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> memberCourseService.toggleBookmark(100L))
+                    .isInstanceOf(GeneralException.class)
+                    .hasMessageContaining(ErrorStatus.MEMBER_NOT_FOUND.getMessage());
+
+            verify(memberRepository).findById(1L);
+        }
+    }
+
+    @Test
+    @DisplayName("북마크 토글 실패 - 존재하지 않는 MemberCourse")
+    void toggleBookmark_fail_memberCourseNotFound() {
+        try (MockedStatic<SecurityUtil> mockedSecurityUtil = mockStatic(SecurityUtil.class)) {
+            // given
+            mockSecurityUtil(mockedSecurityUtil);
+
+            when(memberRepository.findById(1L)).thenReturn(Optional.of(testMember));
+            when(memberCourseRepository.findByCourseIdAndMemberId(999L, 1L))
+                    .thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> memberCourseService.toggleBookmark(999L))
+                    .isInstanceOf(GeneralException.class)
+                    .hasMessageContaining(ErrorStatus.COURSE_MEMBER_NOT_FOUND.getMessage());
+
+            verify(memberCourseRepository).findByCourseIdAndMemberId(999L, 1L);
+        }
+    }
+
+    @Test
+    @DisplayName("북마크된 코스 목록 조회 성공")
+    void findAllCourseByBookmarked_success() {
+        try (MockedStatic<SecurityUtil> mockedSecurityUtil = mockStatic(SecurityUtil.class)) {
+            // given
+            mockSecurityUtil(mockedSecurityUtil);
+
+            MemberCourseResponse responseDto = new MemberCourseResponse(
+                    100L,
+                    CourseType.AI,
+                    "image.jpg",
+                    "AI 코스",
+                    "설명",
+                    List.of("음식점", "카페")
+            );
+
+            Slice<MemberCourseResponse> slice = new SliceImpl<>(List.of(responseDto));
+
+            when(memberCourseRepository.findCourseByBookmarks(eq(1L), eq(10), eq(null)))
+                    .thenReturn(slice);
+
+            // when
+            MemberCourseSliceResponse result = memberCourseService.findAllCourseByBookmarked(10, null);
+
+            // then
+            assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result.content()).hasSize(1),
+                    () -> assertThat(result.content().get(0).courseName()).isEqualTo("AI 코스"),
+                    () -> assertThat(result.isLast()).isTrue()
+            );
+
+            verify(memberCourseRepository).findCourseByBookmarks(eq(1L), eq(10), eq(null));
+        }
+    }
+
+    @Test
+    @DisplayName("북마크된 코스 목록 조회 성공 - 빈 결과")
+    void findAllCourseByBookmarked_success_empty() {
+        try (MockedStatic<SecurityUtil> mockedSecurityUtil = mockStatic(SecurityUtil.class)) {
+            // given
+            mockSecurityUtil(mockedSecurityUtil);
+
+            Slice<MemberCourseResponse> emptySlice = new SliceImpl<>(List.of());
+
+            when(memberCourseRepository.findCourseByBookmarks(eq(1L), eq(10), eq(null)))
+                    .thenReturn(emptySlice);
+
+            // when
+            MemberCourseSliceResponse result = memberCourseService.findAllCourseByBookmarked(10, null);
+
+            // then
+            assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result.content()).isEmpty(),
+                    () -> assertThat(result.isLast()).isTrue()
+            );
+
+            verify(memberCourseRepository).findCourseByBookmarks(eq(1L), eq(10), eq(null));
+        }
+    }
+
+    @Test
+    @DisplayName("내 코스 목록 조회 성공 - 필터링 및 페이징")
+    void getMemberCourses_success() {
+        try (MockedStatic<SecurityUtil> mockedSecurityUtil = mockStatic(SecurityUtil.class)) {
+            // given
+            mockSecurityUtil(mockedSecurityUtil);
+
+            when(memberRepository.findById(1L)).thenReturn(Optional.of(testMember));
+
+            MemberCourseResponse responseDto = new MemberCourseResponse(
+                    100L,
+                    CourseType.DIY,
+                    null,
+                    "테스트 코스",
+                    "설명",
+                    List.of("음식점", "카페")
+            );
+
+            Slice<MemberCourseResponse> slice = new SliceImpl<>(List.of(responseDto));
+
+            CourseType courseType = CourseType.DIY;
+            String upperLoc = "서울시";
+            String lowerLoc = "강남구";
+            Long lastId = 200L;
+
+            when(memberCourseRepository.findCourseByFilters(
+                    eq(courseType), eq(upperLoc), eq(lowerLoc), eq(1L), eq(lastId)
+            )).thenReturn(slice);
+
+            // when
+            MemberCourseSliceResponse result = memberCourseService.getMemberCourses(courseType, upperLoc, lowerLoc, lastId);
+
+            // then
+            assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result.content()).hasSize(1),
+                    () -> assertThat(result.content().get(0).courseName()).isEqualTo("테스트 코스"),
+                    () -> assertThat(result.isLast()).isTrue()
+            );
+
+            verify(memberCourseRepository).findCourseByFilters(
+                    eq(courseType), eq(upperLoc), eq(lowerLoc), eq(1L), eq(lastId)
+            );
+        }
+    }
+
+    @Test
+    @DisplayName("내 코스 목록 조회 성공 - 빈 결과")
+    void getMemberCourses_success_empty() {
+        try (MockedStatic<SecurityUtil> mockedSecurityUtil = mockStatic(SecurityUtil.class)) {
+            // given
+            mockSecurityUtil(mockedSecurityUtil);
+
+            when(memberRepository.findById(1L)).thenReturn(Optional.of(testMember));
+
+            Slice<MemberCourseResponse> emptySlice = new SliceImpl<>(List.of());
+
+            CourseType courseType = CourseType.AI;
+            String upperLoc = "all";
+            String lowerLoc = "all";
+
+            when(memberCourseRepository.findCourseByFilters(
+                    eq(courseType), eq(upperLoc), eq(lowerLoc), eq(1L), eq(null)
+            )).thenReturn(emptySlice);
+
+            // when
+            MemberCourseSliceResponse result = memberCourseService.getMemberCourses(courseType, upperLoc, lowerLoc, null);
+
+            // then
+            assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result.content()).isEmpty(),
+                    () -> assertThat(result.isLast()).isTrue()
+            );
+
+            verify(memberCourseRepository).findCourseByFilters(
+                    eq(courseType), eq(upperLoc), eq(lowerLoc), eq(1L), eq(null)
+            );
+        }
+    }
+}

--- a/src/test/java/umc/catchy/support/fixture/MemberCourseFixture.java
+++ b/src/test/java/umc/catchy/support/fixture/MemberCourseFixture.java
@@ -1,0 +1,54 @@
+package umc.catchy.support.fixture;
+
+import umc.catchy.domain.course.domain.Course;
+import umc.catchy.domain.mapping.memberCourse.domain.MemberCourse;
+import umc.catchy.domain.member.domain.Member;
+
+import java.time.LocalDate;
+
+public class MemberCourseFixture {
+
+    public static MemberCourse createTestMemberCourse(Member member, Course course) {
+        return MemberCourse.builder()
+                .id(1L)
+                .member(member)
+                .course(course)
+                .isVisited(false)
+                .visitedDate(null)
+                .bookmark(false)
+                .build();
+    }
+
+    public static MemberCourse createTestMemberCourse(Long id, Member member, Course course, boolean bookmark) {
+        return MemberCourse.builder()
+                .id(id)
+                .member(member)
+                .course(course)
+                .isVisited(false)
+                .visitedDate(null)
+                .bookmark(bookmark)
+                .build();
+    }
+
+    public static MemberCourse createVisitedMemberCourse(Member member, Course course, LocalDate visitedDate) {
+        return MemberCourse.builder()
+                .id(1L)
+                .member(member)
+                .course(course)
+                .isVisited(true)
+                .visitedDate(visitedDate)
+                .bookmark(false)
+                .build();
+    }
+
+    public static MemberCourse createBookmarkedMemberCourse(Member member, Course course) {
+        return MemberCourse.builder()
+                .id(1L)
+                .member(member)
+                .course(course)
+                .isVisited(false)
+                .visitedDate(null)
+                .bookmark(true)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📌 Issue Number
- close #253

## 🪐 작업 내용
MemberCourse 도메인 리팩토링을 통해 코드 품질 개선 및 쿼리 성능 최적화

## ✅ PR 상세 내용

### 1. N+1 문제 해결
- 코스별 카테고리 개별 조회를 IN 쿼리로 일괄 조회하도록 개선
- 쿼리 수 82% 감소 (11번 → 2번)
- `fetchCategoriesAndBuildResponses` 메서드로 Map 그룹핑을 통한 효율적인 데이터 매핑

### 2. DTO Record 전환
- `MemberCourseResponse`, `CourseBookmarkResponse`를 Record로 전환하여 불변 객체 사용
- QueryDSL 전용 `MemberCourseDto` 생성
- `toResponse()` 메서드로 변환 로직 캡슐화

### 3. 도메인 계층 개선
- `@Setter` 제거하여 무분별한 상태 변경 방지
- `static toggleBookmark`를 인스턴스 메서드로 변경
- `markAsVisited` 도메인 메서드 추가

### 4. 서비스 계층 개선
- `getCurrentMember` 헬퍼 메서드 추출로 중복 코드 제거
- public 필드를 private으로 변경하여 캡슐화 강화
- SecurityUtil 호출 로직 일원화

### 5. 컨트롤러 분리
- CourseController에서 MemberCourseService를 사용하는 API를 MemberCourseController로 이동
  - `GET /course/search` (내 코스 조회)
  - `PATCH /course/{courseId}/bookmark` (북마크 토글)
- CourseService의 `getMemberCourses`를 MemberCourseService로 이동
- 도메인별 책임 분리 및 응집도 향상
- url은 변동 없음

### 6. 코드 품질 개선
- 하드코딩 제거 및 상수화 (`ALL_LOCATION`, `SPACE`, `FILTER_PAGE_SIZE`)
- 매직 넘버 상수화로 가독성 향상

### 7. 테스트 코드 작성
- Controller 테스트 3개 (API 동작 검증)
- Service 테스트 7개 (비즈니스 로직 검증)
- MemberCourseFixture 생성으로 테스트 데이터 생성 패턴 통일