### PR TITLE
[feature] 에러/성능 모니터링 구축

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -63,6 +63,6 @@ jobs:
             sudo docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
             sudo docker image rm ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }} || true
             sudo docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
-            sudo docker-compose up -d --no-deps app
+            sudo docker-compose up -d
             sudo docker-compose logs
             sudo docker image prune -f

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -39,7 +39,8 @@ jobs:
 
       - name: Build with Gradle
         run: ./gradlew bootJar --no-daemon
-
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       - name: Docker build and push
         run: |
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,10 @@ dependencies {
 
 	// Sentry
 	implementation 'io.sentry:sentry-spring-boot-starter:8.22.0'
+
+	// 성능 모니터링
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.4.1'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id "io.sentry.jvm.gradle" version "5.12.2"
 }
 
 group = 'umc'
@@ -17,6 +18,12 @@ dependencyManagement {
 	imports {
 		mavenBom "org.springframework.cloud:spring-cloud-dependencies:2024.0.0"
 	}
+}
+
+sentry {
+	includeSourceContext = true
+	org = "catchy"
+	projectName = "java-spring-boot"
 }
 
 configurations {
@@ -86,6 +93,9 @@ dependencies {
 
 	// OpenFeign
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+	// Sentry
+	implementation 'io.sentry:sentry-spring-boot-starter:8.22.0'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - "8081:8081"
     volumes:
       - ./src/main/resources/application-prod.yml:/config/application-prod.yml
+    networks:
+      - catchy-network
 
   osrm-routed:
     image: osrm/osrm-backend:latest
@@ -19,3 +21,34 @@ services:
       - .:/data
     command: >
       osrm-routed --algorithm mld /data/OSM/south-korea-latest.osrm
+    networks:
+      - catchy-network
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: catchy-prometheus
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    ports:
+      - "9090:9090"
+    networks:
+      - catchy-network
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: catchy-grafana
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana-storage:/var/lib/grafana
+    networks:
+      - catchy-network
+
+networks:
+  catchy-network:
+    driver: bridge
+
+volumes:
+  grafana-storage:

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'catchy-prod-app'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['catchy-server:8081']

--- a/src/main/java/umc/catchy/global/common/response/code/ErrorReasonDTO.java
+++ b/src/main/java/umc/catchy/global/common/response/code/ErrorReasonDTO.java
@@ -11,4 +11,10 @@ public class ErrorReasonDTO {
     private final boolean isSuccess;
     private final String code;
     private final String message;
+
+    @Override
+    public String toString() {
+        return String.format("ErrorReason{code='%s', message='%s', status=%s}",
+                code, message, httpStatus);
+    }
 }

--- a/src/main/java/umc/catchy/global/config/security/SecurityConfig.java
+++ b/src/main/java/umc/catchy/global/config/security/SecurityConfig.java
@@ -44,7 +44,7 @@ public class SecurityConfig {
                                 , "/member/reissue", "/member/callback/**"
                                 ,"/course/generate-ai", "/health"
                                 ,"/course/place/current", "/course/place/region"
-                                , "/member/mypage/nickname").permitAll()
+                                , "/member/mypage/nickname", "/actuator/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(exception -> exception

--- a/src/main/java/umc/catchy/global/error/exception/ExceptionAdvice.java
+++ b/src/main/java/umc/catchy/global/error/exception/ExceptionAdvice.java
@@ -1,5 +1,6 @@
 package umc.catchy.global.error.exception;
 
+import io.sentry.Sentry;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
@@ -28,14 +29,36 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
     private ResponseEntity<Object> createErrorResponse(
             Exception e, ErrorStatus errorStatus, String errorMessage, HttpHeaders headers, WebRequest request) {
-        log.error("Exception: {}, Status: {}, Message: {}", e.getClass().getSimpleName(), errorStatus, errorMessage);
+        log.error("Exception: {}, Code: {}, Message: {}",
+                e.getClass().getSimpleName(), errorStatus.getCode(), errorMessage);
         BaseResponse<Object> body = BaseResponse.onFailure(errorStatus, errorMessage);
         return super.handleExceptionInternal(e, body, headers, errorStatus.getHttpStatus(), request);
     }
 
     private ResponseEntity<Object> createErrorResponse(
             Exception e, ErrorReasonDTO reason, HttpHeaders headers, HttpServletRequest request) {
-        log.error("Exception: {}, Reason: {}", e.getClass().getSimpleName(), reason);
+
+        // 상세 로그 출력 (Sentry가 읽기 쉽게)
+        log.error("Exception: {}, Code: {}, Message: {}, Status: {}",
+                e.getClass().getSimpleName(),
+                reason.getCode(),
+                reason.getMessage(),
+                reason.getHttpStatus().value());
+
+        // Sentry에 상세 정보 추가
+        Sentry.configureScope(scope -> {
+            scope.setTag("error_code", reason.getCode());
+            scope.setTag("http_status", String.valueOf(reason.getHttpStatus().value()));
+            scope.setTag("endpoint", request.getRequestURI());
+            scope.setTag("method", request.getMethod());
+            scope.setExtra("error_message", reason.getMessage());
+        });
+
+        // 500 에러만 Sentry에 전송
+        if (reason.getHttpStatus().is5xxServerError()) {
+            Sentry.captureException(e);
+        }
+
         BaseResponse<Object> body = BaseResponse.onFailure(reason, null);
         WebRequest webRequest = new ServletWebRequest(request);
         return super.handleExceptionInternal(e, body, headers, reason.getHttpStatus(), webRequest);
@@ -43,6 +66,15 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler
     public ResponseEntity<Object> handleGlobalException(Exception e, WebRequest request) {
+        // 예상치 못한 에러는 무조건 Sentry에
+        log.error("Unexpected exception occurred", e);
+
+        Sentry.configureScope(scope -> {
+            scope.setTag("error_type", e.getClass().getSimpleName());
+            scope.setExtra("error_message", e.getMessage());
+        });
+        Sentry.captureException(e);
+
         return createErrorResponse(e, ErrorStatus._INTERNAL_SERVER_ERROR, e.getMessage(), HttpHeaders.EMPTY, request);
     }
 
@@ -52,6 +84,9 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
                 .map(ConstraintViolation::getMessage)
                 .reduce((first, second) -> first + ", " + second)
                 .orElse("Validation error occurred");
+
+        log.warn("Validation error: {}", errorMessage);
+
         return createErrorResponse(e, ErrorStatus.VALIDATION_ERROR, errorMessage, HttpHeaders.EMPTY, request);
     }
 
@@ -70,11 +105,16 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         e.getBindingResult().getFieldErrors()
                 .forEach(fieldError -> errors.put(fieldError.getField(), fieldError.getDefaultMessage()));
         String errorMessage = String.join(", ", errors.values());
+
+        log.warn("Method argument validation failed: {}", errorMessage);
+
         return createErrorResponse(e, ErrorStatus._BAD_REQUEST, errorMessage, headers, request);
     }
 
     @ExceptionHandler(ResultEmptyListException.class)
     public ResponseEntity<Object> handleResultEmptyListException(ResultEmptyListException e, WebRequest request) {
+        log.info("Empty result list: {}", e.getErrorStatus().getCode());
+
         return ResponseEntity
                 .status(e.getErrorStatus().getHttpStatus())
                 .body(BaseResponse.onFailureWithEmptyList(e.getErrorStatus()));

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -88,5 +88,12 @@ cache:
 fcm:
   certification: ${FCM_CERTIFICATION:}
 
+sentry:
+  dsn: ${SENTRY_DSN}
+  environment: production
+  send-default-pii: true
+  attach-stacktrace: true
+  traces-sample-rate: 1.0
+
 server:
   port: 8081

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -95,5 +95,16 @@ sentry:
   attach-stacktrace: true
   traces-sample-rate: 1.0
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus, health, info
+  endpoint:
+    prometheus:
+      enabled: true
+    health:
+      show-details: always
+
 server:
   port: 8081


### PR DESCRIPTION
# 🪐 작업 내용

서비스 운영 안정성 확보 및 실시간 장애 대응을 위해 **에러 트래킹(Sentry)** 및 **성능 모니터링(Prometheus + Grafana)** 환경을 구축했습니다.

---

# 🛠 모니터링 스택

| 구분 | 사용 툴 | 목적 |
| --- | --- | --- |
| **Error Tracking** | **Sentry** | 실시간 애플리케이션 에러 로그 수집 및 알림 |
| **Metrics** | **Prometheus** | 서버 리소스 및 애플리케이션 메트릭 데이터 수집 |
| **Visualization** | **Grafana** | 수집된 메트릭 데이터의 시각화 및 대시보드 제공 |

---

# ✅ 관리자 설정 가이드 (Infrastructure)

> **서버 배포 시 아래 설정 사항들을 반드시 반영해 주셔야 모니터링이 정상 작동합니다.**

### 1. 환경 변수 (`.env`) 설정

* **Sentry DSN 추가:** 아래 노션 페이지를 참고하여 `SENTRY_DSN` 값을 `.env` 파일에 추가해 주세요.
* [🔗 Sentry DSN 확인하기 (Notion)](https://www.notion.so/env-8a11e1187eb74fcdaeaef073db20fff6)



### 2. 모니터링 설정 파일 생성

* **경로:** `/home/ubuntu/app/monitoring/prometheus.yml`
* **내용:** 프로젝트 내 `monitoring/prometheus.yml` 파일을 해당 위치에 생성 및 복사해 주세요.

### 3. AWS EC2 보안 그룹(SG) 포트 개방

외부에서 모니터링 대시보드에 접속할 수 있도록 인바운드 규칙 추가가 필요합니다.

* **3000번 포트:** Grafana 대시보드 접속용
* **9090번 포트:** Prometheus 설정 확인용 (필요 시 개방)

---

# 📦 주요 변경 사항

* **`application-prod.yml`**: Prometheus 메트릭 노출을 위한 Actuator 엔드포인트 활성화
* **`docker-compose.yml`**: Prometheus 및 Grafana 서비스 정의 추가 및 전용 네트워크(`catchy-network`) 설정
* **`monitoring/prometheus.yml`**: 애플리케이션 컨테이너(`catchy-server`) 데이터 수집을 위한 스크레이핑 규칙 정의
* **`github-actions.yml`**: 배포 시 전체 서비스를 갱신하도록 `docker-compose up -d` 명령 수정

---

# 🔍 확인 방법

1. 배포 후 `http://[EC2-IP]:3000`으로 접속하여 Grafana 로그인 여부 확인
2. `http://[EC2-IP]:8081/actuator/prometheus` 접속 시 메트릭 텍스트가 정상 출력되는지 확인
