### PR TITLE
[Test] Group 도메인 서비스 및 컨트롤러 테스트 코드 작성

### DIFF
--- a/src/main/java/umc/catchy/domain/group/service/GroupService.java
+++ b/src/main/java/umc/catchy/domain/group/service/GroupService.java
@@ -79,7 +79,7 @@ public class GroupService {
         Groups group = Groups.create(request, groupImageUrl, promiseTime);
         Groups savedGroup = groupRepository.save(group);
 
-        MemberGroup memberGroup = MemberGroup.create(group, member);
+        MemberGroup memberGroup = MemberGroup.create(savedGroup, member);
         memberGroupRepository.save(memberGroup);
 
         return CreateGroupResponse.of(savedGroup, member.getNickname());

--- a/src/test/java/umc/catchy/domain/group/api/GroupControllerTest.java
+++ b/src/test/java/umc/catchy/domain/group/api/GroupControllerTest.java
@@ -1,0 +1,121 @@
+package umc.catchy.domain.group.api;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import umc.catchy.domain.group.dto.request.CreateGroupRequest;
+import umc.catchy.domain.group.dto.request.InviteCodeRequest;
+import umc.catchy.domain.group.dto.response.*;
+import umc.catchy.domain.group.service.GroupService;
+import umc.catchy.global.util.SecurityUtil;
+import umc.catchy.support.ControllerTestSupport;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(GroupController.class)
+class GroupControllerTest extends ControllerTestSupport {
+
+    @MockitoBean
+    private GroupService groupService;
+
+    @Test
+    @DisplayName("그룹 생성 API 테스트 (Multipart/form-data)")
+    void createGroup_api_test() throws Exception {
+        // given
+        CreateGroupResponse response = new CreateGroupResponse(
+                1L, "테스트 그룹", "서울시 강남구", "https://image.url", "ABC1234",
+                LocalDateTime.of(2025, 1, 25, 15, 30), "테스트유저"
+        );
+
+        try (MockedStatic<SecurityUtil> mockedSecurityUtil = mockStatic(SecurityUtil.class)) {
+            mockedSecurityUtil.when(SecurityUtil::getCurrentMemberId).thenReturn(1L);
+            when(groupService.createGroup(any(CreateGroupRequest.class), eq(1L))).thenReturn(response);
+
+            // when & then
+            mockMvc.perform(multipart("/group")
+                            .file("groupImage", "test.jpg".getBytes())
+                            .param("groupName", "테스트 그룹")
+                            .param("groupLocation", "서울시 강남구")
+                            .param("promiseTime", "2025-01-25T15:30:00")
+                            .param("inviteCode", "ABC1234")
+                            .header("Authorization", testToken))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.isSuccess").value(true))
+                    .andExpect(jsonPath("$.result.groupId").value(1L))
+                    .andExpect(jsonPath("$.result.groupName").value("테스트 그룹"));
+        }
+    }
+
+    @Test
+    @DisplayName("초대 코드로 그룹 가입 API 테스트")
+    void joinGroupByInviteCode_api_test() throws Exception {
+        // given
+        InviteCodeRequest request = new InviteCodeRequest("ABC1234");
+        GroupJoinResponse response = GroupJoinResponse.of(true, "Successfully joined");
+
+        when(groupService.joinGroupByInviteCode(anyString())).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/group/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .header("Authorization", testToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.success").value(true));
+    }
+
+    @Test
+    @DisplayName("사용자가 속한 그룹 조회 API 테스트")
+    void getUserGroups_api_test() throws Exception {
+        // given
+        GroupCalendarResponse response = new GroupCalendarResponse(1L, "1월 약속", LocalDateTime.now());
+        when(groupService.getUserGroups(anyInt(), anyInt())).thenReturn(List.of(response));
+
+        // when & then
+        mockMvc.perform(get("/group/my-groups")
+                        .param("year", "2025")
+                        .param("month", "1")
+                        .header("Authorization", testToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result[0].groupName").value("1월 약속"));
+    }
+
+    @Test
+    @DisplayName("그룹 탈퇴 API 테스트")
+    void leaveGroup_api_test() throws Exception {
+        // when & then
+        mockMvc.perform(delete("/group/{groupId}/leave", 1L)
+                        .header("Authorization", testToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true));
+    }
+
+    @Test
+    @DisplayName("그룹 멤버 조회 API 테스트")
+    void getGroupMembers_api_test() throws Exception {
+        // given
+        GroupMemberResponse memberResponse = new GroupMemberResponse(1L, "유저1", "https://profile.jpg");
+        when(groupService.getGroupMembers(anyLong())).thenReturn(List.of(memberResponse));
+
+        // when & then
+        mockMvc.perform(get("/group/{groupId}/members", 1L)
+                        .header("Authorization", testToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result[0].nickname").value("유저1"));
+    }
+}
+

--- a/src/test/java/umc/catchy/domain/group/service/GroupServiceTest.java
+++ b/src/test/java/umc/catchy/domain/group/service/GroupServiceTest.java
@@ -1,0 +1,289 @@
+package umc.catchy.domain.group.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+import umc.catchy.domain.group.dao.GroupRepository;
+import umc.catchy.domain.group.domain.Groups;
+import umc.catchy.domain.group.dto.request.CreateGroupRequest;
+import umc.catchy.domain.group.dto.response.CreateGroupResponse;
+import umc.catchy.domain.group.dto.response.GroupCalendarResponse;
+import umc.catchy.domain.group.dto.response.GroupJoinResponse;
+import umc.catchy.domain.group.dto.response.GroupMemberResponse;
+import umc.catchy.domain.mapping.memberGroup.dao.MemberGroupRepository;
+import umc.catchy.domain.mapping.memberGroup.domain.MemberGroup;
+import umc.catchy.domain.member.dao.MemberRepository;
+import umc.catchy.domain.member.domain.Member;
+import umc.catchy.global.error.exception.GeneralException;
+import umc.catchy.global.util.SecurityUtil;
+import umc.catchy.infra.aws.s3.AmazonS3Manager;
+import umc.catchy.support.fixture.GroupFixture;
+import umc.catchy.support.fixture.MemberFixture;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GroupServiceTest {
+
+    @InjectMocks
+    private GroupService groupService;
+
+    @Mock
+    private GroupRepository groupRepository;
+
+    @Mock
+    private MemberGroupRepository memberGroupRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private AmazonS3Manager amazonS3Manager;
+
+    @Test
+    @DisplayName("그룹 생성 성공 - 그룹 생성 및 생성자 멤버 등록 검증")
+    void createGroup_success() {
+        // given
+        Long memberId = 1L;
+        CreateGroupRequest request = GroupFixture.createGroupRequest("테스트 그룹", "ABC1234");
+        Member testMember = MemberFixture.createTestMember(memberId, "test@test.com");
+
+        Groups savedGroup = GroupFixture.createGroupWithId(100L, request.groupName(), request.inviteCode());
+
+        ArgumentCaptor<MemberGroup> memberGroupCaptor = ArgumentCaptor.forClass(MemberGroup.class);
+
+        try (MockedStatic<SecurityUtil> mockedSecurityUtil = mockStatic(SecurityUtil.class)) {
+            mockedSecurityUtil.when(SecurityUtil::getCurrentMemberId).thenReturn(memberId);
+
+            when(memberRepository.findById(memberId)).thenReturn(Optional.of(testMember));
+            when(amazonS3Manager.uploadFile(anyString(), any(MultipartFile.class)))
+                    .thenReturn("https://catchy-s3.com/group-images/test-image.jpg");
+
+            when(groupRepository.save(any(Groups.class))).thenReturn(savedGroup);
+
+            // when
+            CreateGroupResponse response = groupService.createGroup(request, memberId);
+
+            // then
+            assertAll(
+                    () -> assertThat(response).isNotNull(),
+                    () -> assertThat(response.groupId()).isEqualTo(100L),
+                    () -> assertThat(response.groupName()).isEqualTo("테스트 그룹"),
+                    () -> {
+                        verify(memberGroupRepository).save(memberGroupCaptor.capture());
+                        MemberGroup capturedMemberGroup = memberGroupCaptor.getValue();
+                        assertThat(capturedMemberGroup.getGroup()).isEqualTo(savedGroup);
+                        assertThat(capturedMemberGroup.getMember()).isEqualTo(testMember);
+                    }
+            );
+
+            verify(memberRepository, times(1)).findById(memberId);
+            verify(groupRepository, times(1)).save(any(Groups.class));
+            verify(memberGroupRepository, times(1)).save(any(MemberGroup.class));
+        }
+    }
+
+    @Test
+    @DisplayName("초대 코드로 그룹 가입 성공")
+    void joinGroupByInviteCode_success() {
+        // given
+        Long memberId = 1L;
+        String inviteCode = "ABC1234";
+        Member testMember = MemberFixture.createTestMember(memberId, "test@test.com");
+        Groups existingGroup = GroupFixture.createGroupWithId(100L, "기존 그룹", inviteCode);
+
+        ArgumentCaptor<MemberGroup> memberGroupCaptor = ArgumentCaptor.forClass(MemberGroup.class);
+
+        try (MockedStatic<SecurityUtil> mockedSecurityUtil = mockStatic(SecurityUtil.class)) {
+            mockedSecurityUtil.when(SecurityUtil::getCurrentMemberId).thenReturn(memberId);
+
+            when(memberRepository.findById(memberId)).thenReturn(Optional.of(testMember));
+            when(groupRepository.findByInviteCode(inviteCode)).thenReturn(Optional.of(existingGroup));
+
+            when(memberGroupRepository.existsByGroupIdAndMemberId(existingGroup.getId(), memberId))
+                    .thenReturn(false);
+
+            // when
+            GroupJoinResponse response = groupService.joinGroupByInviteCode(inviteCode);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.success()).isTrue(),
+                    () -> assertThat(response.message()).isEqualTo("Successfully joined the group."),
+                    () -> {
+                        verify(memberGroupRepository).save(memberGroupCaptor.capture());
+                        MemberGroup capturedMemberGroup = memberGroupCaptor.getValue();
+                        assertThat(capturedMemberGroup.getMember()).isEqualTo(testMember);
+                        assertThat(capturedMemberGroup.getGroup()).isEqualTo(existingGroup);
+                    }
+            );
+
+            verify(memberRepository, times(1)).findById(memberId);
+            verify(groupRepository, times(1)).findByInviteCode(inviteCode);
+        }
+    }
+
+    @Test
+    @DisplayName("초대 코드로 그룹 가입 실패 - 이미 가입된 회원")
+    void joinGroupByInviteCode_fail_already_exists() {
+        // given
+        Long memberId = 1L;
+        String inviteCode = "ABC1234";
+        Groups existingGroup = GroupFixture.createGroupWithId(100L, "기존 그룹", inviteCode);
+
+        try (MockedStatic<SecurityUtil> mockedSecurityUtil = mockStatic(SecurityUtil.class)) {
+            mockedSecurityUtil.when(SecurityUtil::getCurrentMemberId).thenReturn(memberId);
+
+            when(memberRepository.findById(memberId)).thenReturn(Optional.of(mock(Member.class)));
+            when(groupRepository.findByInviteCode(inviteCode)).thenReturn(Optional.of(existingGroup));
+
+            when(memberGroupRepository.existsByGroupIdAndMemberId(existingGroup.getId(), memberId))
+                    .thenReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> groupService.joinGroupByInviteCode(inviteCode))
+                    .isInstanceOf(GeneralException.class)
+                    .hasMessageContaining("이미 그룹에 가입된 회원입니다.");
+
+            verify(memberGroupRepository, never()).save(any(MemberGroup.class));
+        }
+    }
+
+    @Test
+    @DisplayName("사용자가 속한 그룹 조회 - 년/월 필터링 검증")
+    void getUserGroups_filtering_success() {
+        // given
+        Long memberId = 1L;
+        int targetYear = 2025;
+        int targetMonth = 1;
+
+        Member testMember = MemberFixture.createTestMember(memberId, "test@test.com");
+
+        // 1. 조건에 맞는 그룹 (2025년 1월)
+        Groups group1 = GroupFixture.createGroupWithIdAndYearAndMonth(101L, 2025, 1);
+
+        // 2. 조건에 맞지 않는 그룹 (2025년 2월 - 월이 다름)
+        Groups group2 = GroupFixture.createGroupWithIdAndYearAndMonth(102L, 2025, 2);
+
+        // 3. 조건에 맞지 않는 그룹 (2024년 1월 - 년도가 다름)
+        Groups group3 = GroupFixture.createGroupWithIdAndYearAndMonth(103L, 2024, 1);
+
+        MemberGroup mg1 = MemberGroup.create(group1, testMember);
+        MemberGroup mg2 = MemberGroup.create(group2, testMember);
+        MemberGroup mg3 = MemberGroup.create(group3, testMember);
+
+        try (MockedStatic<SecurityUtil> mockedSecurityUtil = mockStatic(SecurityUtil.class)) {
+            mockedSecurityUtil.when(SecurityUtil::getCurrentMemberId).thenReturn(memberId);
+
+            when(memberRepository.findById(memberId)).thenReturn(Optional.of(testMember));
+            when(memberGroupRepository.findAllByMemberId(memberId)).thenReturn(List.of(mg1, mg2, mg3));
+
+            // when
+            List<GroupCalendarResponse> result = groupService.getUserGroups(targetYear, targetMonth);
+
+            // then
+            assertAll(
+                    () -> assertThat(result).hasSize(1),
+                    () -> assertThat(result.get(0).groupId()).isEqualTo(101L),
+                    () -> assertThat(result.get(0).promiseTime().getYear()).isEqualTo(targetYear),
+                    () -> assertThat(result.get(0).promiseTime().getMonthValue()).isEqualTo(targetMonth)
+            );
+
+            verify(memberRepository, times(1)).findById(memberId);
+            verify(memberGroupRepository, times(1)).findAllByMemberId(memberId);
+        }
+    }
+
+    @Test
+    @DisplayName("그룹 탈퇴 성공")
+    void leaveGroup_success() {
+        // given
+        Long memberId = 1L;
+        Long groupId = 100L;
+        Member testMember = MemberFixture.createTestMember(memberId, "test@test.com");
+        Groups existingGroup = GroupFixture.createGroupWithId(groupId, "탈퇴할 그룹", "BYE123");
+        MemberGroup memberGroup = MemberGroup.create(existingGroup, testMember);
+
+        try (MockedStatic<SecurityUtil> mockedSecurityUtil = mockStatic(SecurityUtil.class)) {
+            mockedSecurityUtil.when(SecurityUtil::getCurrentMemberId).thenReturn(memberId);
+
+            when(memberRepository.findById(memberId)).thenReturn(Optional.of(testMember));
+            when(groupRepository.findById(groupId)).thenReturn(Optional.of(existingGroup));
+            when(memberGroupRepository.findByGroupIdAndMemberId(groupId, memberId))
+                    .thenReturn(Optional.of(memberGroup));
+
+            // when
+            groupService.leaveGroup(groupId);
+
+            // then
+            verify(memberGroupRepository, times(1)).delete(memberGroup);
+        }
+    }
+
+    @Test
+    @DisplayName("그룹 탈퇴 실패 - 그룹에 속하지 않은 멤버")
+    void leaveGroup_fail_member_not_in_group() {
+        // given
+        Long memberId = 1L;
+        Long groupId = 100L;
+        Member testMember = MemberFixture.createTestMember(memberId, "test@test.com");
+        Groups existingGroup = GroupFixture.createGroupWithId(groupId, "탈퇴할 그룹", "BYE123");
+
+        try (MockedStatic<SecurityUtil> mockedSecurityUtil = mockStatic(SecurityUtil.class)) {
+            mockedSecurityUtil.when(SecurityUtil::getCurrentMemberId).thenReturn(memberId);
+
+            when(memberRepository.findById(memberId)).thenReturn(Optional.of(testMember));
+            when(groupRepository.findById(groupId)).thenReturn(Optional.of(existingGroup));
+            when(memberGroupRepository.findByGroupIdAndMemberId(groupId, memberId))
+                    .thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> groupService.leaveGroup(groupId))
+                    .isInstanceOf(GeneralException.class)
+                    .hasMessageContaining("사용자가 그룹에 속해 있지 않습니다.");
+
+            verify(memberGroupRepository, never()).delete(any(MemberGroup.class));
+        }
+    }
+
+    @Test
+    @DisplayName("그룹 멤버 조회 성공")
+    void getGroupMembers_success() {
+        // given
+        Long groupId = 100L;
+        Member member1 = MemberFixture.createTestMember(1L, "user1@test.com");
+        Member member2 = MemberFixture.createTestMember(2L, "user2@test.com");
+        List<Member> members = List.of(member1, member2);
+
+        when(memberGroupRepository.findMembersByGroupId(groupId)).thenReturn(members);
+
+        // when
+        List<GroupMemberResponse> result = groupService.getGroupMembers(groupId);
+
+        // then
+        assertAll(
+                () -> assertThat(result).hasSize(2),
+                () -> assertThat(result.get(0).memberId()).isEqualTo(1L),
+                () -> assertThat(result.get(0).nickname()).isEqualTo(member1.getNickname()),
+                () -> assertThat(result.get(1).memberId()).isEqualTo(2L),
+                () -> assertThat(result.get(1).profileImage()).isEqualTo(member2.getProfileImage())
+        );
+
+        verify(memberGroupRepository, times(1)).findMembersByGroupId(groupId);
+    }
+}

--- a/src/test/java/umc/catchy/support/fixture/GroupFixture.java
+++ b/src/test/java/umc/catchy/support/fixture/GroupFixture.java
@@ -1,0 +1,63 @@
+package umc.catchy.support.fixture;
+
+import org.springframework.mock.web.MockMultipartFile;
+import umc.catchy.domain.group.domain.Groups;
+import umc.catchy.domain.group.dto.request.CreateGroupRequest;
+
+import java.time.LocalDateTime;
+
+public class GroupFixture {
+
+    public static CreateGroupRequest createGroupRequest(String name, String inviteCode) {
+        MockMultipartFile mockImage = new MockMultipartFile(
+                "groupImage",
+                "test-image.jpg",
+                "image/jpeg",
+                "test-image-content".getBytes()
+        );
+
+        return new CreateGroupRequest(
+                name,
+                "서울시 강남구 테헤란로",
+                LocalDateTime.of(2025, 1, 25, 15, 30),
+                inviteCode,
+                mockImage
+        );
+    }
+
+    public static Groups createGroup(String name, String inviteCode) {
+        return Groups.builder()
+                .groupName(name)
+                .groupLocation("서울시 강남구 테헤란로")
+                .promiseTime(LocalDateTime.of(2025, 1, 25, 15, 30))
+                .inviteCode(inviteCode)
+                .groupImage("https://catchy-s3.com/group-images/test-image.jpg")
+                .build();
+    }
+
+    public static Groups createGroupWithId(Long id, String name, String inviteCode) {
+        return Groups.builder()
+                .id(id)
+                .groupName(name)
+                .groupLocation("서울시 강남구 테헤란로")
+                .sido("서울")
+                .sigungu("강남구")
+                .promiseTime(LocalDateTime.of(2025, 1, 25, 15, 30))
+                .inviteCode(inviteCode)
+                .groupImage("https://catchy-s3.com/group-images/test-image.jpg")
+                .build();
+    }
+
+    public static Groups createGroupWithIdAndYearAndMonth(Long id, int year, int month) {
+        return Groups.builder()
+                .id(id)
+                .groupName("테스트 그룹")
+                .groupLocation("서울시 강남구 테헤란로")
+                .sido("서울")
+                .sigungu("강남구")
+                .promiseTime(LocalDateTime.of(year, month, 25, 15, 30))
+                .inviteCode("ABC123")
+                .groupImage("https://catchy-s3.com/group-images/test-image.jpg")
+                .build();
+    }
+}


### PR DESCRIPTION
## 🪐 작업 내용
- Group 도메인 테스트 환경 구축: Service 및 Controller 계층 테스트 코드 작성
- 테스트 피스처 도입: GroupFixture 생성을 통한 테스트 데이터 관리 효율화
- 서비스 로직 개선: 객체 참조 정합성을 위한 GroupService 리팩토링

## ✅ PR 상세 내용
-  **GroupFixture 구현**: Groups 엔티티와 CreateGroupRequest의 반복적인 생성을 static 메서드로 공통화했습니다.
- **GroupService 단위 테스트**: 그룹 생성, 초대 코드 가입, 탈퇴, 필터링 조회 등 주요 비즈니스 로직과 예외 상황(중복 가입 등)을 검증했습니다.
- **GroupController API 테스트**: MockMvc를 활용해 Multipart 요청 및 JSON 응답 구조가 API 명세와 일치하는지 확인했습니다.
- **로직 최적화**: 그룹 생성 시 영속화된 객체(savedGroup)를 사용하여 MemberGroup 매핑 시 발생하던 참조 불일치 문제를 해결했습니다.